### PR TITLE
Hooks

### DIFF
--- a/R/FitnessFunction.R
+++ b/R/FitnessFunction.R
@@ -23,8 +23,6 @@
 #'   Optional, can override the Measure in the Task
 #' * `param_set` ([paradox::ParamSet]):
 #'   Parameter Set.
-#' * `terminator` (`Terminator`):
-#'   A [Terminator] which controls the termination of the tuning.
 #' * `tune_control` (`list()`):
 #'   See [tune_control()].
 #'
@@ -46,20 +44,19 @@ FitnessFunction = R6Class("FitnessFunction",
     resampling = NULL,
     measures = NULL,
     param_set = NULL,
-    terminator = NULL,
     ctrl = NULL,
-
+    hooks = NULL,
     experiments = NULL,
 
-    initialize = function(task, learner, resampling, measures = NULL, param_set, terminator, ctrl = tune_control()) {
+    initialize = function(task, learner, resampling, measures = NULL, param_set, ctrl = tune_control()) {
       self$task = mlr3::assert_task(task)
       self$learner = mlr3::assert_learner(learner, task = task)
       self$resampling = mlr3::assert_resampling(resampling)
       self$measures = mlr3::assert_measures(measures %??% task$measures, task = task, learner = learner)
       self$param_set = assert_class(param_set, "ParamSet")
-      self$terminator = assert_class(terminator$clone(), "Terminator")
       self$ctrl = assert_list(ctrl, names = "unique")
       self$experiments = data.table()
+      self$hooks = list(update_start = list(), update_end = list())
     },
 
     rbind = function(experiments) {
@@ -77,20 +74,16 @@ FitnessFunction = R6Class("FitnessFunction",
     },
 
     eval_vectorized = function(xs) {
-      if (self$terminator$terminated) {
-        stop(paste("Terminator: ", self$terminator$message))
-      }
-
       learners = lapply(xs, function(x) {
         learner = self$learner$clone()
         learner$param_vals = insert.list(learner$param_vals, x)
         return(learner)
       })
 
-      self$terminator$update_start(self)
+      self$run_hooks("update_start")
       bmr = mlr3::benchmark(tasks = list(self$task), learners = learners, resamplings = list(self$resampling), measures = self$measures, ctrl = self$ctrl)
       self$rbind(bmr$data)
-      self$terminator$update_end(self)
+      self$run_hooks("update_end")
       invisible(self)
     },
 
@@ -101,6 +94,12 @@ FitnessFunction = R6Class("FitnessFunction",
       m = self$measures[[1L]]
       perfs = bmr$aggregated
       bmr$resample_result(perfs$hash[which_best(m, perfs[[m$id]])])
+    },
+
+    run_hooks = function(id) {
+      funs = self$hooks[[id]]
+      for (fun in funs)
+        do.call(fun, list(ff = self))
     }
   )
 )

--- a/R/TunerGridSearch.R
+++ b/R/TunerGridSearch.R
@@ -5,17 +5,20 @@
 #'
 #' @section Usage:
 #' ```
-#' tuner = TunerGridSearch$new(ff, resolution)
+#' tuner = TunerGridSearch$new(ff, terminator, resolution)
 #' ```
 #' See [Tuner] for a description of the interface.
 #'
 #' @section Arguments:
 #' * `id` (`character(1)`):
 #'   The id of the Tuner.
+#' * `terminator` ([Terminator]):
+#'   Terminator to control the termination.
+#'   Will be triggered by the hooks of the [FitnessFunction].
 #' * `resolution` (`integer(1)`):
 #'   Resolution of the grid.
 #'   If none is specified we will try to calculate the resolution form the Terminator.
-
+#'
 #' @section Details:
 #' `$new()` creates a new object of class [TunerGridSearch].
 #' The interface is described in [Tuner].
@@ -28,16 +31,15 @@
 #' learner = mlr3::mlr_learners$get("classif.rpart")
 #' resampling = mlr3::mlr_resamplings$get("cv")
 #' measures = mlr3::mlr_measures$mget("mmce")
-#' terminator = TerminatorEvaluations$new(10)
 #' param_set = paradox::ParamSet$new(
 #'   params = list(
 #'     paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1)
 #'   )
 #' )
+#' ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
 #'
-#' ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-#'
-#' rs = TunerGridSearch$new(ff)
+#' terminator = TerminatorEvaluations$new(10)
+#' rs = TunerGridSearch$new(ff, terminator)
 #' rs$tune()$tune_result()
 NULL
 
@@ -46,14 +48,14 @@ NULL
 TunerGridSearch = R6Class("TunerGridSearch",
   inherit = Tuner,
   public = list(
-    initialize = function(ff, resolution = NULL) {
+    initialize = function(ff, terminator, resolution = NULL) {
       if (is.null(resolution)) {
-        remaining = ff$terminator$remaining
-        assertInt(remaining, lower = 1L)
-        resolution = floor(remaining ^ 1 / ff$param_set$length)
+        remaining = terminator$remaining
+        assert_int(remaining, lower = 1L)
+        resolution = floor(remaining / ff$param_set$length)
       }
-      assertInt(resolution, lower = 1L)
-      super$initialize(id = "grid_search", ff = ff, settings = list(resolution = resolution))
+      resolution = assert_int(resolution, lower = 1L, coerce = TRUE)
+      super$initialize(id = "grid_search", ff = ff, terminator = terminator, settings = list(resolution = resolution))
     }
   ),
 

--- a/R/TunerRandomSearch.R
+++ b/R/TunerRandomSearch.R
@@ -5,13 +5,16 @@
 #'
 #' @section Usage:
 #' ```
-#' tuner = TunerRandomSearch$new(ff, batch_size = 100L)
+#' tuner = TunerRandomSearch$new(ff, terminator, batch_size = 100L)
 #' ```
 #' See [Tuner] for a description of the interface.
 #'
 #' @section Arguments:
 #' * `id` (`character(1)`):
 #'   The id of the Tuner.
+#' * `terminator` ([Terminator]):
+#'   Terminator to control the termination.
+#'   Will be triggered by the hooks of the [FitnessFunction].
 #' * `batch_size` (`integer(1)`):
 #'   Maximum number of configurations to try in a batch.
 #'   Each batch is possibly executed in parallel via [mlr3::benchmark()].
@@ -28,16 +31,15 @@
 #' learner = mlr3::mlr_learners$get("classif.rpart")
 #' resampling = mlr3::mlr_resamplings$get("cv")
 #' measures = mlr3::mlr_measures$mget("mmce")
-#' terminator = TerminatorEvaluations$new(10)
 #' param_set = paradox::ParamSet$new(
 #'   params = list(
 #'    paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1)
 #'   )
 #' )
+#' ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
 #'
-#' ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-#'
-#' rs = TunerRandomSearch$new(ff)
+#' terminator = TerminatorEvaluations$new(10)
+#' rs = TunerRandomSearch$new(ff, terminator)
 #' rs$tune()$tune_result()
 NULL
 
@@ -46,15 +48,15 @@ NULL
 TunerRandomSearch = R6Class("TunerRandomSearch",
   inherit = Tuner,
   public = list(
-    initialize = function(ff, batch_size = 100L) {
+    initialize = function(ff, terminator, batch_size = 100L) {
       batch_size = assert_count(batch_size, coerce = TRUE)
-      super$initialize(id = "random_search", ff = ff, settings = list(batch_size = batch_size))
+      super$initialize(id = "random_search", ff = ff, terminator = terminator, settings = list(batch_size = batch_size))
     }
   ),
 
   private = list(
     tune_step = function() {
-      n = min(self$settings$batch_size, self$ff$terminator$remaining)
+      n = min(self$settings$batch_size, self$terminator$remaining)
       xs = self$ff$param_set$sample(n)
       xs = self$ff$param_set$transform(xs)
       self$ff$eval_vectorized(.mapply(list, xs, list()))

--- a/man/FitnessFunction.Rd
+++ b/man/FitnessFunction.Rd
@@ -28,8 +28,6 @@ The Resampling method that is used to obtain the y value.
 Optional, can override the Measure in the Task
 \item \code{param_set} (\link[paradox:ParamSet]{paradox::ParamSet}):
 Parameter Set.
-\item \code{terminator} (\code{Terminator}):
-A \link{Terminator} which controls the termination of the tuning.
 \item \code{tune_control} (\code{list()}):
 See \code{\link[=tune_control]{tune_control()}}.
 }

--- a/man/Tuner.Rd
+++ b/man/Tuner.Rd
@@ -23,6 +23,8 @@ tuner$tune_result()
 \itemize{
 \item \code{id} (\code{character(1)}):
 The id of the Tuner.
+\item \code{ff} (\link{FitnessFunction}).
+\item \code{terminator} (\link{Terminator}).
 \item \code{settings} (\code{list}):
 The settings for the Tuner.
 }
@@ -34,6 +36,7 @@ The settings for the Tuner.
 \item \code{$new()} creates a new object of class \link{Tuner}.
 \item \code{id} stores an identifier for this \link{Tuner}.
 \item \code{ff} stores the \link{FitnessFunction} to optimize.
+\item \code{terminator} stores the \link{Terminator}.
 \item \code{settings} is a list of hyperparamter settings for this \link{Tuner}.
 \item \code{tune()} performs the tuning, until the budget of the \link{Terminator} in the \link{FitnessFunction} is exhausted.
 \item \code{tune_result()} returns a list with 2 elements:

--- a/man/TunerGridSearch.Rd
+++ b/man/TunerGridSearch.Rd
@@ -7,7 +7,7 @@
 TunerGridSearch
 }
 \section{Usage}{
-\preformatted{tuner = TunerGridSearch$new(ff, resolution)
+\preformatted{tuner = TunerGridSearch$new(ff, terminator, resolution)
 }
 
 See \link{Tuner} for a description of the interface.
@@ -18,6 +18,9 @@ See \link{Tuner} for a description of the interface.
 \itemize{
 \item \code{id} (\code{character(1)}):
 The id of the Tuner.
+\item \code{terminator} (\link{Terminator}):
+Terminator to control the termination.
+Will be triggered by the hooks of the \link{FitnessFunction}.
 \item \code{resolution} (\code{integer(1)}):
 Resolution of the grid.
 If none is specified we will try to calculate the resolution form the Terminator.
@@ -35,16 +38,15 @@ task = mlr3::mlr_tasks$get("iris")
 learner = mlr3::mlr_learners$get("classif.rpart")
 resampling = mlr3::mlr_resamplings$get("cv")
 measures = mlr3::mlr_measures$mget("mmce")
-terminator = TerminatorEvaluations$new(10)
 param_set = paradox::ParamSet$new(
   params = list(
     paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1)
   )
 )
+ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
 
-ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-
-rs = TunerGridSearch$new(ff)
+terminator = TerminatorEvaluations$new(10)
+rs = TunerGridSearch$new(ff, terminator)
 rs$tune()$tune_result()
 }
 \seealso{

--- a/man/TunerRandomSearch.Rd
+++ b/man/TunerRandomSearch.Rd
@@ -7,7 +7,7 @@
 TunerRandomSearch
 }
 \section{Usage}{
-\preformatted{tuner = TunerRandomSearch$new(ff, batch_size = 100L)
+\preformatted{tuner = TunerRandomSearch$new(ff, terminator, batch_size = 100L)
 }
 
 See \link{Tuner} for a description of the interface.
@@ -18,6 +18,9 @@ See \link{Tuner} for a description of the interface.
 \itemize{
 \item \code{id} (\code{character(1)}):
 The id of the Tuner.
+\item \code{terminator} (\link{Terminator}):
+Terminator to control the termination.
+Will be triggered by the hooks of the \link{FitnessFunction}.
 \item \code{batch_size} (\code{integer(1)}):
 Maximum number of configurations to try in a batch.
 Each batch is possibly executed in parallel via \code{\link[mlr3:benchmark]{mlr3::benchmark()}}.
@@ -35,16 +38,15 @@ task = mlr3::mlr_tasks$get("iris")
 learner = mlr3::mlr_learners$get("classif.rpart")
 resampling = mlr3::mlr_resamplings$get("cv")
 measures = mlr3::mlr_measures$mget("mmce")
-terminator = TerminatorEvaluations$new(10)
 param_set = paradox::ParamSet$new(
   params = list(
    paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1)
   )
 )
+ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
 
-ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-
-rs = TunerRandomSearch$new(ff)
+terminator = TerminatorEvaluations$new(10)
+rs = TunerRandomSearch$new(ff, terminator)
 rs$tune()$tune_result()
 }
 \seealso{

--- a/tests/testthat/test_FitnessFunction.R
+++ b/tests/testthat/test_FitnessFunction.R
@@ -7,7 +7,6 @@ test_that("Construction", {
   resampling = mlr3::mlr_resamplings$get("holdout")
   measures = mlr3::mlr_measures$mget("mmce")
   param_set = paradox::ParamSet$new(params = list(paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1)))
-  terminator = TerminatorIterations$new(3)
 
   ff = FitnessFunction$new(
     task = task,
@@ -15,7 +14,6 @@ test_that("Construction", {
     resampling = resampling,
     measures = measures,
     param_set = param_set,
-    terminator = terminator,
     ctrl = tune_control(store_prediction = TRUE) # for the exceptions
   )
 

--- a/tests/testthat/test_TunerGridSearch.R
+++ b/tests/testthat/test_TunerGridSearch.R
@@ -8,13 +8,14 @@ test_that("TunerGridSearch",  {
   resampling = mlr3::mlr_resamplings$get("cv")
   resampling$param_vals = list(folds = 2)
   measures = mlr3::mlr_measures$mget("mmce")
+
   terminator = TerminatorEvaluations$new(5)
   param_set = paradox::ParamSet$new(params = list(
       paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1
   )))
 
-  ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-  gs = TunerGridSearch$new(ff)
+  ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
+  gs = TunerGridSearch$new(ff, terminator = terminator)
 
   result = gs$tune()$tune_result()
   exps = gs$ff$experiments

--- a/tests/testthat/test_TunerRandomSearch.R
+++ b/tests/testthat/test_TunerRandomSearch.R
@@ -12,8 +12,8 @@ test_that("TunerRandomSearch",  {
       paradox::ParamReal$new("cp", lower = 0.001, upper = 0.1
   )))
 
-  ff = FitnessFunction$new(task, learner, resampling, measures, param_set, terminator)
-  rs = TunerRandomSearch$new(ff)
+  ff = FitnessFunction$new(task, learner, resampling, measures, param_set)
+  rs = TunerRandomSearch$new(ff, terminator)
 
   result = rs$tune()$tune_result()
   exps = rs$ff$experiments


### PR DESCRIPTION
FF now has hooks "update_start" and "update_end" which are lists of functions. These get automatically called by the fitness function during `eval()` / `eval_vectorized()`.

Terminators are now not part of the FF any more, but get passed to the tuner. The Tuner sets the respective hooks of the Terminator in the FF so that no tuner can "cheat".

IMHO the interface is now cleaner. Also solves #1.