### PR TITLE
Remove archive output, add best result and state of instance

### DIFF
--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -213,15 +213,24 @@ TuningInstance = R6Class("TuningInstance",
 
     print = function() {
       catf(self$format())
+      catf(str_indent("* State: ", if(self$n_evals == 0) "Not tuned" else "Tuned"))
       catf(str_indent("* Task:", format(self$task)))
       catf(str_indent("* Learner:", format(self$learner)))
       catf(str_indent("* Measures:", map_chr(self$measures, "id")))
       catf(str_indent("* Resampling:", format(self$resampling)))
       catf(str_indent("* Terminator:", format(self$terminator)))
       catf(str_indent("* bm_args:", as_short_string(self$bm_args)))
+      catf(str_indent("* n_evals:", self$n_evals))
+      if(self$n_evals != 0) {
+        catf("* Result:")
+        catf(strwrap("perf:", indent = 3))
+        catf(strwrap(c(rbind(names(self$result$perf), self$result$perf)), indent = 4), sep = "\n")
+        catf(strwrap("tune_x:", indent = 3))
+        catf(strwrap(c(rbind(names(self$result$tune_x), self$result$tune_x)), indent = 4), sep = "\n")
+        catf(strwrap("params:", indent = 3))
+        catf(strwrap(c(rbind(names(self$result$params), self$result$params)), indent = 4), sep = "\n")
+      }
       print(self$param_set)
-      catf("Archive:")
-      print(self$archive())
     },
 
     # evaluates all points in a design

--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -222,17 +222,12 @@ TuningInstance = R6Class("TuningInstance",
       catf(str_indent("* bm_args:", as_short_string(self$bm_args)))
       catf(str_indent("* n_evals:", self$n_evals))
       if(!is.null(self$result$perf)) {
-        catf("* Result:")
-        catf("   perf:")
-        catf(paste0("   ", capture.output(as.data.table(rbind(self$result$perf)))), sep= "\n")
-        catf("   tune_x:")
-        catf(paste0("   ", capture.output(as.data.table(self$result$tune_x))), sep= "\n")
-        catf("   params:")
-        catf(paste0("   ", capture.output(as.data.table(self$result$params))), sep= "\n")
+        catf("* Result perf:")
+        print(as.data.table(rbind(self$result$perf)))
+        catf("* Result tune_x:")
+        print(as.data.table(rbind(self$result$tune_x)))
       }
-      pps = capture.output(self$param_set)
-      catf("* ParamSet:")
-      cat(paste("  ", pps[2:length(pps)]), sep = "\n")
+      print(self$param_set)
     },
 
     # evaluates all points in a design

--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -222,10 +222,8 @@ TuningInstance = R6Class("TuningInstance",
       catf(str_indent("* bm_args:", as_short_string(self$bm_args)))
       catf(str_indent("* n_evals:", self$n_evals))
       if(!is.null(self$result$perf)) {
-        catf("* Result perf:")
-        print(as.data.table(rbind(self$result$perf)))
-        catf("* Result tune_x:")
-        print(as.data.table(rbind(self$result$tune_x)))
+        catf(str_indent("* Result perf:", as_short_string(as.list(instance$result$perf))) )
+        catf(str_indent("* Result tune_x:", as_short_string(instance$result$tune_x)))
       }
       print(self$param_set)
     },

--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -223,14 +223,16 @@ TuningInstance = R6Class("TuningInstance",
       catf(str_indent("* n_evals:", self$n_evals))
       if(!is.null(self$result$perf)) {
         catf("* Result:")
-        catf(strwrap("perf:", indent = 3))
-        catf(strwrap(c(rbind(names(self$result$perf), self$result$perf)), indent = 4), sep = "\n")
-        catf(strwrap("tune_x:", indent = 3))
-        catf(strwrap(c(rbind(names(self$result$tune_x), self$result$tune_x)), indent = 4), sep = "\n")
-        catf(strwrap("params:", indent = 3))
-        catf(strwrap(c(rbind(names(self$result$params), self$result$params)), indent = 4), sep = "\n")
+        catf("   perf:")
+        catf(paste0("   ", capture.output(as.data.table(rbind(self$result$perf)))), sep= "\n")
+        catf("   tune_x:")
+        catf(paste0("   ", capture.output(as.data.table(self$result$tune_x))), sep= "\n")
+        catf("   params:")
+        catf(paste0("   ", capture.output(as.data.table(self$result$params))), sep= "\n")
       }
-      print(self$param_set)
+      pps = capture.output(self$param_set)
+      catf("* ParamSet:")
+      cat(paste("  ", pps[2:length(pps)]), sep = "\n")
     },
 
     # evaluates all points in a design

--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -222,8 +222,8 @@ TuningInstance = R6Class("TuningInstance",
       catf(str_indent("* bm_args:", as_short_string(self$bm_args)))
       catf(str_indent("* n_evals:", self$n_evals))
       if(!is.null(self$result$perf)) {
-        catf(str_indent("* Result perf:", as_short_string(as.list(instance$result$perf))) )
-        catf(str_indent("* Result tune_x:", as_short_string(instance$result$tune_x)))
+        catf(str_indent("* Result perf:", as_short_string(as.list(self$result$perf))) )
+        catf(str_indent("* Result tune_x:", as_short_string(self$result$tune_x)))
       }
       print(self$param_set)
     },

--- a/R/TuningInstance.R
+++ b/R/TuningInstance.R
@@ -213,7 +213,7 @@ TuningInstance = R6Class("TuningInstance",
 
     print = function() {
       catf(self$format())
-      catf(str_indent("* State: ", if(self$n_evals == 0) "Not tuned" else "Tuned"))
+      catf(str_indent("* State: ", if(is.null(self$result$perf)) "Not tuned" else "Tuned"))
       catf(str_indent("* Task:", format(self$task)))
       catf(str_indent("* Learner:", format(self$learner)))
       catf(str_indent("* Measures:", map_chr(self$measures, "id")))
@@ -221,7 +221,7 @@ TuningInstance = R6Class("TuningInstance",
       catf(str_indent("* Terminator:", format(self$terminator)))
       catf(str_indent("* bm_args:", as_short_string(self$bm_args)))
       catf(str_indent("* n_evals:", self$n_evals))
-      if(self$n_evals != 0) {
+      if(!is.null(self$result$perf)) {
         catf("* Result:")
         catf(strwrap("perf:", indent = 3))
         catf(strwrap(c(rbind(names(self$result$perf), self$result$perf)), indent = 4), sep = "\n")

--- a/tests/testthat/test_TuningInstance.R
+++ b/tests/testthat/test_TuningInstance.R
@@ -5,7 +5,7 @@ test_that("TuningInstance", {
   # test empty inst
   expect_data_table(inst$bmr$data, nrows = 0)
   expect_identical(inst$n_evals, 0L)
-  expect_output(print(inst), "Empty data.table")
+  expect_output(print(inst), "Not tuned")
 
   # add a couple of eval points and test the state of inst
   z = inst$eval_batch(data.table(cp = c(0.01, 0.02), minsplit = c(3, 4)))
@@ -17,7 +17,7 @@ test_that("TuningInstance", {
   expect_equal(inst$bmr$resample_result(2)$learners[[1]]$param_set$values$minsplit, 4)
   expect_equal(inst$bmr$resample_result(2)$learners[[1]]$param_set$values$maxdepth, 10)
   expect_identical(inst$n_evals, 2L)
-  expect_output(print(inst), "0.02")
+  expect_output(print(inst), "Tuned")
   expect_list(z, len = 3)
   expect_named(z, c("batch_nr", "uhashes", "perf"))
   expect_equal(z$batch_nr, 1L)

--- a/tests/testthat/test_TuningInstance.R
+++ b/tests/testthat/test_TuningInstance.R
@@ -17,7 +17,7 @@ test_that("TuningInstance", {
   expect_equal(inst$bmr$resample_result(2)$learners[[1]]$param_set$values$minsplit, 4)
   expect_equal(inst$bmr$resample_result(2)$learners[[1]]$param_set$values$maxdepth, 10)
   expect_identical(inst$n_evals, 2L)
-  expect_output(print(inst), "Tuned")
+  expect_output(print(inst), "Not tuned")
   expect_list(z, len = 3)
   expect_named(z, c("batch_nr", "uhashes", "perf"))
   expect_equal(z$batch_nr, 1L)


### PR DESCRIPTION
Closes #206 

Output before tuning

```r
<TuningInstance>
* State:  Not tuned
* Task: <TaskClassif:iris>
* Learner: <LearnerClassifRpart:classif.rpart>
* Measures: classif.ce, classif.acc
* Resampling: <ResamplingHoldout>
* Terminator: <TerminatorEvals>
* bm_args: list()
* n_evals: 0
ParamSet: 
   id    class lower upper levels     default value
1: cp ParamDbl     0  0.05        <NoDefault>
```

Output after tuning

```r
 <TuningInstance>
* State:  Tuned
* Task: <TaskClassif:iris>
* Learner: <LearnerClassifRpart:classif.rpart>
* Measures: classif.ce, classif.acc
* Resampling: <ResamplingHoldout>
* Terminator: <TerminatorEvals>
* bm_args: list()
* n_evals: 20
* Result:
   perf:
    classif.ce
    0.06
    classif.acc
    0.94
   tune_x:
    cp
    0.00173121183179319
   params:
    xval
    0
    cp
    0.00173121183179319
ParamSet: 
   id    class lower upper levels     default value
1: cp ParamDbl     0  0.05        <NoDefault> 
```

~~If we just use `$eval_batch` instead of `$tune` the output looks like this~~ Fixed with new commit

```r
 <TuningInstance>
* State:  Tuned
* Task: <TaskClassif:iris>
* Learner: <LearnerClassifRpart:classif.rpart>
* Measures: classif.ce, classif.acc
* Resampling: <ResamplingHoldout>
* Terminator: <TerminatorEvals>
* bm_args: list()
* n_evals: 2
* Result:
   perf:

   tune_x:

   params:
    xval
    0
ParamSet: 
   id    class lower upper levels     default value
1: cp ParamDbl     0  0.05        <NoDefault>  
```
since no results were written to `private$.result` by a Tuner class. Should we omit the result output in this case?