### PR TITLE
Add check_values to TuningInstance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     rpart,
     testthat
 Remotes:
-    mlr-org/bbotk@check_values,
+    mlr-org/bbotk,
     mlr-org/paradox
 Encoding: UTF-8
 NeedsCompilation: no

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Remotes:
 Encoding: UTF-8
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Collate:
     'AutoTuner.R'
     'ObjectiveTuning.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     rpart,
     testthat
 Remotes:
-    mlr-org/bbotk,
+    mlr-org/bbotk@check_values,
     mlr-org/paradox
 Encoding: UTF-8
 NeedsCompilation: no

--- a/R/ObjectiveTuning.R
+++ b/R/ObjectiveTuning.R
@@ -36,8 +36,11 @@ ObjectiveTuning = R6Class("ObjectiveTuning",
     #' @param measures list of [mlr3::Measure]
     #' @param terminator [Terminator]
     #' @param store_models `logical(1)`
+    #' @param check_values ('logical(1)')\cr
+    #' Should parameters before the evaluation and the results be checked for
+    #' validity?
     initialize = function(task, learner, resampling, measures,
-      store_models = FALSE) {
+      store_models = FALSE, check_values = TRUE) {
         self$task = assert_task(as_task(task, clone = TRUE))
         self$learner = assert_learner(as_learner(learner, clone = TRUE),
           task = self$task)
@@ -60,14 +63,12 @@ ObjectiveTuning = R6Class("ObjectiveTuning",
 
       super$initialize(
         id = sprintf("%s_on_%s", self$learner$id, self$task$id), domain = self$learner$param_set,
-        codomain = codomain)
-    },
+        codomain = codomain, check_values = check_values)
+    }
+  ),
 
-    #' @description
-    #' Evaluates multiple hyperparameter sets on the objective function.
-    #' @param xss `list()`\cr
-    #' A list of lists that contains multiple hyperparameter sets.
-    eval_many = function(xss) {
+  private = list(
+    .eval_many = function(xss) {
       learners = map(xss, function(x) {
         learner = self$learner$clone(deep = TRUE)
         learner$param_set$values = insert_named(learner$param_set$values, x)

--- a/R/Tuner.R
+++ b/R/Tuner.R
@@ -140,7 +140,7 @@ Tuner = R6Class("Tuner",
     #' @description
     #' Performs the tuning on a [TuningInstanceSingleCrit] or
     #' [TuningInstanceMultiCrit] until termination.
-    #' The results will be stored in the [bbotk::Archive] that resides in the [TuningInstanceSingleCrit]/[TuningInstanceMultiCrit].
+    #' The single evaluations and the final results will be written into the [bbotk::Archive] that resides in the [TuningInstanceSingleCrit]/[TuningInstanceMultiCrit].
     #'
     #' @param inst ([TuningInstanceSingleCrit] | [TuningInstanceMultiCrit]).
     #'

--- a/R/Tuner.R
+++ b/R/Tuner.R
@@ -140,6 +140,7 @@ Tuner = R6Class("Tuner",
     #' @description
     #' Performs the tuning on a [TuningInstanceSingleCrit] or
     #' [TuningInstanceMultiCrit] until termination.
+    #' The results will be stored in the [bbotk::Archive] that resides in the [TuningInstanceSingleCrit]/[TuningInstanceMultiCrit].
     #'
     #' @param inst ([TuningInstanceSingleCrit] | [TuningInstanceMultiCrit]).
     #'

--- a/R/TuningInstanceMulticrit.R
+++ b/R/TuningInstanceMulticrit.R
@@ -31,11 +31,15 @@ TuningInstanceMultiCrit = R6Class("TuningInstanceMultiCrit",
     #'
     #' @param terminator ([Terminator])
     #' @param store_models `logical(1)`
+    #'
+    #' @param check_values (`logical(1)`)
+    #' Should parameters before the evaluation and the results be checked for
+    #' validity?
     initialize = function(task, learner, resampling, measures, search_space,
-      terminator, store_models = FALSE) {
+      terminator, store_models = FALSE, check_values = TRUE) {
         obj = ObjectiveTuning$new(task = task, learner = learner,
           resampling = resampling, measures = measures,
-          store_models = store_models)
+          store_models = store_models, check_values = check_values)
         super$initialize(obj, search_space, terminator)
     },
 

--- a/R/TuningInstanceSingleCrit.R
+++ b/R/TuningInstanceSingleCrit.R
@@ -119,12 +119,15 @@ TuningInstanceSingleCrit = R6Class("TuningInstanceSingleCrit",
     #'
     #' @param terminator ([Terminator])
     #' @param store_models `logical(1)`
+    #' @param check_values (`logical(1)`)
+    #' Should parameters before the evaluation and the results be checked for
+    #' validity?
     initialize = function(task, learner, resampling, measure, search_space,
-      terminator, store_models = FALSE) {
+      terminator, store_models = FALSE, check_values = TRUE) {
         measure = as_measure(measure)
         obj = ObjectiveTuning$new(task = task, learner = learner,
           resampling = resampling, measures = list(measure),
-          store_models = store_models)
+          store_models = store_models, check_values = check_values)
         super$initialize(obj, search_space, terminator)
     },
 

--- a/man/ObjectiveTuning.Rd
+++ b/man/ObjectiveTuning.Rd
@@ -30,17 +30,15 @@ by the \link{TuningInstanceSingleCrit} / \link{TuningInstanceMultiCrit}.
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{ObjectiveTuning$new()}}
-\item \href{#method-eval_many}{\code{ObjectiveTuning$eval_many()}}
 \item \href{#method-clone}{\code{ObjectiveTuning$clone()}}
 }
 }
 \if{html}{
-\out{<details ><summary>Inherited methods</summary>}
+\out{<details open ><summary>Inherited methods</summary>}
 \itemize{
 \item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="eval">}\href{../../bbotk/html/Objective.html#method-eval}{\code{bbotk::Objective$eval()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="eval_checked">}\href{../../bbotk/html/Objective.html#method-eval_checked}{\code{bbotk::Objective$eval_checked()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="eval_dt">}\href{../../bbotk/html/Objective.html#method-eval_dt}{\code{bbotk::Objective$eval_dt()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="eval_many_checked">}\href{../../bbotk/html/Objective.html#method-eval_many_checked}{\code{bbotk::Objective$eval_many_checked()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="eval_many">}\href{../../bbotk/html/Objective.html#method-eval_many}{\code{bbotk::Objective$eval_many()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="format">}\href{../../bbotk/html/Objective.html#method-format}{\code{bbotk::Objective$format()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="bbotk" data-topic="Objective" data-id="print">}\href{../../bbotk/html/Objective.html#method-print}{\code{bbotk::Objective$print()}}\out{</span>}
 }
@@ -55,7 +53,14 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ObjectiveTuning$new(task, learner, resampling, measures, store_models = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ObjectiveTuning$new(
+  task,
+  learner,
+  resampling,
+  measures,
+  store_models = FALSE,
+  check_values = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -71,25 +76,11 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 
 \item{\code{store_models}}{\code{logical(1)}}
 
-\item{\code{terminator}}{\link{Terminator}}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-eval_many"></a>}}
-\if{latex}{\out{\hypertarget{method-eval_many}{}}}
-\subsection{Method \code{eval_many()}}{
-Evaluates multiple hyperparameter sets on the objective function.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ObjectiveTuning$eval_many(xss)}\if{html}{\out{</div>}}
-}
+\item{\code{check_values}}{('logical(1)')\cr
+Should parameters before the evaluation and the results be checked for
+validity?}
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{xss}}{\code{list()}\cr
-A list of lists that contains multiple hyperparameter sets.}
+\item{\code{terminator}}{\link{Terminator}}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TuningInstanceMultiCrit.Rd
+++ b/man/TuningInstanceMultiCrit.Rd
@@ -53,7 +53,8 @@ and a termination criterion.
   measures,
   search_space,
   terminator,
-  store_models = FALSE
+  store_models = FALSE,
+  check_values = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -76,6 +77,10 @@ Measures to optimize.}
 \item{\code{terminator}}{(\link{Terminator})}
 
 \item{\code{store_models}}{\code{logical(1)}}
+
+\item{\code{check_values}}{(\code{logical(1)})
+Should parameters before the evaluation and the results be checked for
+validity?}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TuningInstanceSingleCrit.Rd
+++ b/man/TuningInstanceSingleCrit.Rd
@@ -142,7 +142,8 @@ and a termination criterion.
   measure,
   search_space,
   terminator,
-  store_models = FALSE
+  store_models = FALSE,
+  check_values = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -165,6 +166,10 @@ Measure to optimize.}
 \item{\code{terminator}}{(\link{Terminator})}
 
 \item{\code{store_models}}{\code{logical(1)}}
+
+\item{\code{check_values}}{(\code{logical(1)})
+Should parameters before the evaluation and the results be checked for
+validity?}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_TuningInstanceSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceSingleCrit.R
@@ -114,6 +114,9 @@ test_that("non-scalar hyperpars (#201)", {
   requireNamespace("mlr3pipelines")
   `%>>%` = getFromNamespace("%>>%", asNamespace("mlr3pipelines"))
 
+
+  learner = mlr3pipelines::po("select") %>>% lrn("classif.rpart")
+
   search_space = ParamSet$new(list(
     ParamInt$new("classif.rpart.minsplit", 1, 1)))
   search_space$trafo = function(x, param_set) {

--- a/tests/testthat/test_TuningInstanceSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceSingleCrit.R
@@ -119,7 +119,7 @@ test_that("non-scalar hyperpars (#201)", {
     rsmp("holdout"), msr("classif.ce"),
     paradox::ParamSet$new(list(
         paradox::ParamInt$new("classif.rpart.minsplit", 1, 1))),
-    term("evals", n_evals=1))
+    term("evals", n_evals=1), check_values = FALSE)
 
   tnr("random_search")$optimize(inst)
   expect_data_table(inst$archive$data(), nrows = 1)

--- a/tests/testthat/test_TuningInstanceSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceSingleCrit.R
@@ -114,12 +114,18 @@ test_that("non-scalar hyperpars (#201)", {
   requireNamespace("mlr3pipelines")
   `%>>%` = getFromNamespace("%>>%", asNamespace("mlr3pipelines"))
 
+  search_space = ParamSet$new(list(
+    ParamInt$new("classif.rpart.minsplit", 1, 1)))
+  search_space$trafo = function(x, param_set) {
+    x$select.selector = mlr3pipelines::selector_all()
+    return(x)
+  }
+
   inst = TuningInstanceSingleCrit$new(tsk("iris"),
-    mlr3pipelines::po("select") %>>% lrn("classif.rpart"),
+    learner,
     rsmp("holdout"), msr("classif.ce"),
-    paradox::ParamSet$new(list(
-        paradox::ParamInt$new("classif.rpart.minsplit", 1, 1))),
-    term("evals", n_evals=1), check_values = FALSE)
+    search_space,
+    term("evals", n_evals = 1), check_values = TRUE)
 
   tnr("random_search")$optimize(inst)
   expect_data_table(inst$archive$data(), nrows = 1)


### PR DESCRIPTION
* Added `check_values` flag `TuningInstanceSingleCrit` and `TuningInstanceMultiCrit` because `ObjectiveTuning` is not created by the user (s. https://github.com/mlr-org/bbotk/pull/98)

# Issues

If a graph contains required parameters (unrelated to the learner) and `check_values = TRUE`, `self$domain$assert` in `bbotk::Objective$eval_many()` fails with `Missing required parameters`