### PR TITLE
don't attempt to attachNamespace() twice

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,5 @@
 library(mlr3)
-attachNamespace("checkmate")
+if (!"package:checkmate" %in% search()) attachNamespace("checkmate")
 # The upstream package causes partial match warnings
 # old_opts = options(
 #   warnPartialMatchArgs = TRUE,


### PR DESCRIPTION
doing so is an error (at least on R 3.6.3)

I'm surprised this isn't triggered already, given the library(checkmate) in testthat.R 🤔