### PR TITLE
feat: set `smooth = FALSE` for GenSA default

### DIFF
--- a/R/TunerGenSA.R
+++ b/R/TunerGenSA.R
@@ -6,6 +6,9 @@
 #' Subclass for generalized simulated annealing tuning calling [GenSA::GenSA()]
 #' from package \CRANpkg{GenSA}.
 #'
+#' In contrast to the [GenSA::GenSA()] defaults, we set `smooth = FALSE` as a
+#' default.
+#'
 #' @templateVar id gensa
 #' @template section_dictionary_tuners
 #'
@@ -31,8 +34,10 @@ TunerGenSA = R6Class("TunerGenSA",
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function() {
+      optimizer = OptimizerGenSA$new()
+      optimizer$param_set$values$smooth = FALSE
       super$initialize(
-        optimizer = OptimizerGenSA$new(),
+        optimizer = optimizer,
         man = "mlr3tuning::mlr_tuners_gensa"
       )
     }

--- a/man/mlr_tuners_gensa.Rd
+++ b/man/mlr_tuners_gensa.Rd
@@ -18,6 +18,9 @@ Xiang Y, Gubian S, Suomela B, Hoeng J (2013).
 \description{
 Subclass for generalized simulated annealing tuning calling \code{\link[GenSA:GenSA]{GenSA::GenSA()}}
 from package \CRANpkg{GenSA}.
+
+In contrast to the \code{\link[GenSA:GenSA]{GenSA::GenSA()}} defaults, we set \code{smooth = FALSE} as a
+default.
 }
 \section{Dictionary}{
 


### PR DESCRIPTION
See related PR and discussion in bbotk here: mlr-org/bbotk#182

Essentially just go with `smooth = FALSE` as a default for HPO.