### PR TITLE
fix: as_data_table() functions do not unnest the `x_domain` colum anymore by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3tuning (development version)
 
+fix: The `as_data_table()` functions do not unnest the `x_domain` colum anymore by default.
+
 # mlr3tuning 1.0.2
 
 * refactor: Extract internal tuned values in instance.

--- a/R/ArchiveAsyncTuning.R
+++ b/R/ArchiveAsyncTuning.R
@@ -184,7 +184,7 @@ ArchiveAsyncTuning = R6Class("ArchiveAsyncTuning",
 )
 
 #' @export
-as.data.table.ArchiveAsyncTuning = function(x, ..., unnest = c("x_domain", "internal_tuned_values"), exclude_columns = NULL, measures = NULL) {
+as.data.table.ArchiveAsyncTuning = function(x, ..., unnest = "internal_tuned_values", exclude_columns = NULL, measures = NULL) {
   data = x$data_with_state()
   if (!nrow(data)) return(data.table())
 

--- a/R/ArchiveBatchTuning.R
+++ b/R/ArchiveBatchTuning.R
@@ -180,7 +180,7 @@ ArchiveBatchTuning = R6Class("ArchiveBatchTuning",
 )
 
 #' @export
-as.data.table.ArchiveBatchTuning = function(x, ..., unnest = c("x_domain", "internal_tuned_values"), exclude_columns = "uhash", measures = NULL) {
+as.data.table.ArchiveBatchTuning = function(x, ..., unnest = "internal_tuned_values", exclude_columns = "uhash", measures = NULL) {
   if (!nrow(x$data)) return(data.table())
   data = copy(x$data)
 

--- a/tests/testthat/test_ArchiveAsyncTuning.R
+++ b/tests/testthat/test_ArchiveAsyncTuning.R
@@ -71,32 +71,32 @@ test_that("ArchiveAsyncTuning as.data.table function works", {
   # default
   tab = as.data.table(instance$archive)
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   # extra measure
   tab = as.data.table(instance$archive, measures = msr("classif.acc"))
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors", "classif.acc"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors", "classif.acc"))
 
   # extra measures
   tab = as.data.table(instance$archive, measures = msrs(c("classif.acc", "classif.mcc")))
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors", "classif.acc", "classif.mcc"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors", "classif.acc", "classif.mcc"))
 
   # exclude column
   tab = as.data.table(instance$archive, exclude_columns = "timestamp_xs")
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "resample_result", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   # exclude columns
   tab = as.data.table(instance$archive, exclude_columns = c("timestamp_xs", "resample_result"))
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   # no exclude
   tab = as.data.table(instance$archive, exclude_columns = NULL)
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   # no unnest
   tab = as.data.table(instance$archive, unnest = NULL)
@@ -125,7 +125,7 @@ test_that("ArchiveAsyncTuning as.data.table function works without resample resu
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain_cp", "runtime_learners", "worker_id", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "cp", "classif.ce", "x_domain", "runtime_learners", "worker_id", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   expect_rush_reset(instance$rush)
 })
@@ -182,7 +182,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with new ids in x_dom
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "x1", "x2", "classif.ce", "x_domain_cp", "x_domain_minsplit", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "x1", "x2", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   expect_rush_reset(instance$rush)
 })
@@ -221,7 +221,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with switched new ids
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, min.rows = 20)
-  expect_names(names(tab), permutation.of = c("state", "x1", "x2", "classif.ce", "x_domain_cp", "x_domain_minsplit", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
+  expect_names(names(tab), permutation.of = c("state", "x1", "x2", "classif.ce", "x_domain", "runtime_learners", "worker_id", "resample_result", "timestamp_xs", "timestamp_ys", "pid", "keys", "warnings", "errors"))
 
   expect_rush_reset(instance$rush)
 })

--- a/tests/testthat/test_ArchiveBatchTuning.R
+++ b/tests/testthat/test_ArchiveBatchTuning.R
@@ -128,32 +128,32 @@ test_that("ArchiveTuning as.data.table function works", {
   # default
   tab = as.data.table(instance$archive)
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of =  c("cp", "classif.ce", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of =  c("cp", "classif.ce", "x_domain", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
 
   # extra measure
   tab = as.data.table(instance$archive, measures = msr("classif.acc"))
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "classif.acc", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "classif.acc", "x_domain", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
 
   # extra measures
   tab = as.data.table(instance$archive, measures = msrs(c("classif.acc", "classif.mcc")))
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "classif.acc", "classif.mcc", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "classif.acc", "classif.mcc", "x_domain", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
 
   # exclude column
   tab = as.data.table(instance$archive, exclude_columns = "timestamp")
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain_cp", "runtime_learners", "batch_nr", "uhash", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain", "runtime_learners", "batch_nr", "uhash", "resample_result", "errors", "warnings"))
 
   # exclude columns
   tab = as.data.table(instance$archive, exclude_columns = c("timestamp", "uhash"))
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain_cp", "runtime_learners", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain", "runtime_learners", "batch_nr", "resample_result", "errors", "warnings"))
 
   # no exclude
   tab = as.data.table(instance$archive, exclude_columns = NULL)
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "uhash", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain", "runtime_learners", "timestamp", "batch_nr", "uhash", "resample_result", "errors", "warnings"))
 
   # no unnest
   tab = as.data.table(instance$archive, unnest = NULL)
@@ -175,7 +175,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, nrows = 4, ncols = 8)
-  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("cp", "classif.ce", "x_domain", "runtime_learners", "timestamp", "batch_nr", "errors", "warnings"))
 
   # empty archive
   instance = ti(
@@ -214,7 +214,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, nrows = 4)
-  expect_names(names(tab), permutation.of = c("x1", "x2", "classif.ce", "x_domain_minsplit", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("x1", "x2", "classif.ce", "x_domain", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
 
   # new ids in x_domain switch
   search_space = ps(
@@ -243,7 +243,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   tab = as.data.table(instance$archive)
   expect_data_table(tab, nrows = 100)
-  expect_names(names(tab), permutation.of = c("x1", "x2", "classif.ce", "x_domain_minsplit", "x_domain_cp", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
+  expect_names(names(tab), permutation.of = c("x1", "x2", "classif.ce", "x_domain", "runtime_learners", "timestamp", "batch_nr", "resample_result", "errors", "warnings"))
 
   # row order
  instance = ti(

--- a/tests/testthat/test_TuningInstanceBatchSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchSingleCrit.R
@@ -36,7 +36,7 @@ test_that("TuningInstanceBatchSingleCrit", {
   expect_data_table(a, nrows = 4L)
   a = as.data.table(inst$archive)
   expect_data_table(a, nrows = 4L)
-  expect_true("x_domain_cp" %in% colnames(a))
+  expect_true("x_domain" %in% colnames(a))
   expect_true("dummy.cp.classif" %in% colnames(a))
 })
 


### PR DESCRIPTION
…more by default