### PR TITLE
fix(at): unused AB and check on required params

### DIFF
--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -143,7 +143,7 @@ AutoTuner = R6Class("AutoTuner",
       ) {
       learner = assert_learner(as_learner(learner, clone = TRUE))
 
-      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token")) > 0) {
+      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token", check_required = FALSE)) > 0) {
         stop("If the values of the ParamSet of the Learner contain TuneTokens you cannot supply a search_space.")
       }
 
@@ -288,13 +288,6 @@ AutoTuner = R6Class("AutoTuner",
   ),
 
   active = list(
-    #' @field internal_valid_scores
-    #' Retrieves the inner validation scores as a named `list()`.
-    #' Returns `NULL` if learner is not trained yet.
-    internal_valid_scores = function() {
-      self$state$internal_valid_scores
-    },
-
     #' @field archive [ArchiveBatchTuning]\cr
     #' Archive of the [TuningInstanceBatchSingleCrit].
     archive = function() self$tuning_instance$archive,

--- a/R/TuningInstanceAsyncMulticrit.R
+++ b/R/TuningInstanceAsyncMulticrit.R
@@ -58,7 +58,7 @@ TuningInstanceAsyncMultiCrit = R6Class("TuningInstanceAsyncMultiCrit",
       callbacks = assert_async_tuning_callbacks(as_callbacks(callbacks))
 
       # tune token and search space
-      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token"))) {
+      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token", check_required = FALSE))) {
         stop("If the values of the ParamSet of the Learner contain TuneTokens you cannot supply a search_space.")
       }
 

--- a/R/TuningInstanceAsyncSingleCrit.R
+++ b/R/TuningInstanceAsyncSingleCrit.R
@@ -68,7 +68,7 @@ TuningInstanceAsyncSingleCrit = R6Class("TuningInstanceAsyncSingleCrit",
       callbacks = assert_async_tuning_callbacks(as_callbacks(callbacks))
 
       # tune token and search space
-      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token"))) {
+      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token", check_required = FALSE))) {
         stop("If the values of the ParamSet of the Learner contain TuneTokens you cannot supply a search_space.")
       }
 

--- a/R/TuningInstanceBatchMulticrit.R
+++ b/R/TuningInstanceBatchMulticrit.R
@@ -87,7 +87,7 @@ TuningInstanceBatchMultiCrit = R6Class("TuningInstanceBatchMultiCrit",
       callbacks = assert_batch_tuning_callbacks(as_callbacks(callbacks))
 
       # tune token and search space
-      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token"))) {
+      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token", check_required = FALSE))) {
         stop("If the values of the ParamSet of the Learner contain TuneTokens you cannot supply a search_space.")
       }
 
@@ -129,7 +129,7 @@ TuningInstanceBatchMultiCrit = R6Class("TuningInstanceBatchMultiCrit",
 
       # set learner parameter values
       if (search_space_from_tokens) {
-        learner$param_set$values = learner$param_set$get_values(type = "without_token")
+        learner$param_set$values = learner$param_set$get_values(type = "without_token", check_required = TRUE)
       }
 
       if (!is.null(self$internal_search_space) && self$internal_search_space$has_trafo) {

--- a/R/TuningInstanceBatchSingleCrit.R
+++ b/R/TuningInstanceBatchSingleCrit.R
@@ -137,7 +137,7 @@ TuningInstanceBatchSingleCrit = R6Class("TuningInstanceBatchSingleCrit",
       callbacks = assert_batch_tuning_callbacks(as_callbacks(callbacks))
 
       # tune token and search space
-      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token"))) {
+      if (!is.null(search_space) && length(learner$param_set$get_values(type = "only_token", check_required = FALSE))) {
         stop("If the values of the ParamSet of the Learner contain TuneTokens you cannot supply a search_space.")
       }
 

--- a/man/AutoTuner.Rd
+++ b/man/AutoTuner.Rd
@@ -154,9 +154,6 @@ Optimization algorithm.}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{internal_valid_scores}}{Retrieves the inner validation scores as a named \code{list()}.
-Returns \code{NULL} if learner is not trained yet.}
-
 \item{\code{archive}}{\link{ArchiveBatchTuning}\cr
 Archive of the \link{TuningInstanceBatchSingleCrit}.}
 

--- a/man/mlr_tuners_cmaes.Rd
+++ b/man/mlr_tuners_cmaes.Rd
@@ -11,7 +11,7 @@ Hansen N (2016).
 }
 \description{
 Subclass for Covariance Matrix Adaptation Evolution Strategy (CMA-ES).
-Calls \code{\link[adagio:cmaes]{adagio::pureCMAES()}} from package \CRANpkg{adagio}.
+Calls \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}} from package \CRANpkg{adagio}.
 }
 \section{Dictionary}{
 
@@ -29,7 +29,7 @@ Create \code{random} start values or based on \code{center} of search space?
 In the latter case, it is the center of the parameters before a trafo is applied.}
 }
 
-For the meaning of the control parameters, see \code{\link[adagio:cmaes]{adagio::pureCMAES()}}.
+For the meaning of the control parameters, see \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}}.
 Note that we have removed all control parameters which refer to the termination of the algorithm and where our terminators allow to obtain the same behavior.
 }
 


### PR DESCRIPTION
1. `internal_valid_scores` is some unremoved leftover
2. When calling `$get_values()` in the `$initialize()` method of the `AutoTuner` this can fail when required parameters are part of the search space but not set in the learner.