### PR TITLE
feat(check): better error message when measure's minimize is NA

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -1,6 +1,9 @@
 measures_to_codomain = function(measures) {
   measures = as_measures(measures)
   domains = map(measures, function(s) {
+    if (is.na(s$minimize)) {
+      stopf("Measure %s has its `minimize` field set to NA, which is disallowed when tuning.", s$id)
+    }
     p_dbl(tags = ifelse(s$minimize, "minimize", "maximize"))
   })
   names(domains) = ids(measures)

--- a/man/AutoTuner.Rd
+++ b/man/AutoTuner.Rd
@@ -197,6 +197,7 @@ Hash (unique identifier) for this partial object, excluding some components whic
 \if{html}{\out{
 <details><summary>Inherited methods</summary>
 <ul>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="Learner" data-id="configure"><a href='../../mlr3/html/Learner.html#method-Learner-configure'><code>mlr3::Learner$configure()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Learner" data-id="encapsulate"><a href='../../mlr3/html/Learner.html#method-Learner-encapsulate'><code>mlr3::Learner$encapsulate()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Learner" data-id="format"><a href='../../mlr3/html/Learner.html#method-Learner-format'><code>mlr3::Learner$format()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Learner" data-id="help"><a href='../../mlr3/html/Learner.html#method-Learner-help'><code>mlr3::Learner$help()</code></a></span></li>

--- a/man/mlr_tuners_cmaes.Rd
+++ b/man/mlr_tuners_cmaes.Rd
@@ -11,7 +11,7 @@ Hansen N (2016).
 }
 \description{
 Subclass for Covariance Matrix Adaptation Evolution Strategy (CMA-ES).
-Calls \code{\link[adagio:cmaes]{adagio::pureCMAES()}} from package \CRANpkg{adagio}.
+Calls \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}} from package \CRANpkg{adagio}.
 }
 \section{Dictionary}{
 
@@ -29,7 +29,7 @@ Create \code{random} start values or based on \code{center} of search space?
 In the latter case, it is the center of the parameters before a trafo is applied.}
 }
 
-For the meaning of the control parameters, see \code{\link[adagio:cmaes]{adagio::pureCMAES()}}.
+For the meaning of the control parameters, see \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}}.
 Note that we have removed all control parameters which refer to the termination of the algorithm and where our terminators allow to obtain the same behavior.
 }
 

--- a/tests/testthat/test_Tuner.R
+++ b/tests/testthat/test_Tuner.R
@@ -434,3 +434,15 @@ test_that("Can only pass internal tune tokens one way", {
     term_evals = 2),
     "Either tag parameters")
 })
+
+test_that("Correct error when minimize is NA", {
+  m = msr("classif.acc")
+  m$minimize = NA
+  expect_error(tune(
+    tuner = tnr("random_search"),
+    task = tsk("iris"),
+    learner = lrn("classif.debug", x = to_tune()),
+    resampling = rsmp("holdout"),
+    measure = m
+  ), "`minimize`")
+})


### PR DESCRIPTION
Meta measures such as `msr("internal_valid_score")` can have their `$minimize` field set to `NA` (unless the user specified it explicitly), which lead to weird error messages.