### PR TITLE
fix: handle points without resample result in as.data.table()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     nloptr,
     processx,
     redux,
-    rush (>= 1.0.0),
+    rush (>= 1.2.0),
     rmarkdown,
     rpart,
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # mlr3tuning (development version)
 
 * Minimum required version of `rush` is now 1.0.0. Removed all compatibility workarounds for older versions.
-* fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points. The extra measures are `NA` for these points.
+* fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
+  The extra measures are `NA` for these points.
 
 # mlr3tuning 1.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3tuning (development version)
 
 * Minimum required version of `rush` is now 1.0.0. Removed all compatibility workarounds for older versions.
+* fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points. The extra measures are `NA` for these points.
 
 # mlr3tuning 1.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3tuning (development version)
 
-* Minimum required version of `rush` is now 1.0.0. Removed all compatibility workarounds for older versions.
+* Minimum required version of `rush` is now 1.2.0.
+  Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
 

--- a/R/ArchiveAsyncTuning.R
+++ b/R/ArchiveAsyncTuning.R
@@ -216,7 +216,14 @@ as.data.table.ArchiveAsyncTuning = function(
   if (!is.null(measures) && !is.null(tab$resample_result)) {
     measures = assert_measures(as_measures(measures), learner = x$learners(1)[[1]], task = x$resample_result(1)$task)
     cols_y_extra = map_chr(measures, "id")
-    scores = map_dtr(x$data$resample_result, function(rr) as.data.table(as.list(rr$aggregate(measures))))
+    # queued, running, and failed points have no resample result
+    scores = map_dtr(tab$resample_result, function(rr) {
+      if (is.null(rr)) {
+        as.data.table(named_list(cols_y_extra, NA_real_))
+      } else {
+        as.data.table(as.list(rr$aggregate(measures)))
+      }
+    })
     tab = cbind(tab, scores)
   }
 

--- a/R/ArchiveAsyncTuningFrozen.R
+++ b/R/ArchiveAsyncTuningFrozen.R
@@ -164,7 +164,14 @@ as.data.table.ArchiveAsyncTuningFrozen = function(
   if (!is.null(measures) && !is.null(tab$resample_result)) {
     measures = assert_measures(as_measures(measures), learner = x$learners(1)[[1]], task = x$resample_result(1)$task)
     cols_y_extra = map_chr(measures, "id")
-    scores = map_dtr(x$data$resample_result, function(rr) as.data.table(as.list(rr$aggregate(measures))))
+    # queued, running, and failed points have no resample result
+    scores = map_dtr(tab$resample_result, function(rr) {
+      if (is.null(rr)) {
+        as.data.table(named_list(cols_y_extra, NA_real_))
+      } else {
+        as.data.table(as.list(rr$aggregate(measures)))
+      }
+    })
     tab = cbind(tab, scores)
   }
 

--- a/tests/testthat/test_ArchiveAsyncTuning.R
+++ b/tests/testthat/test_ArchiveAsyncTuning.R
@@ -271,6 +271,33 @@ test_that("ArchiveAsyncTuning as.data.table function works without resample resu
   )
 })
 
+test_that("ArchiveAsyncTuning as.data.table function works with failed points", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 5),
+    store_benchmark_result = TRUE,
+    rush = rush
+  )
+  tuner = tnr("async_random_search")
+  tuner$optimize(instance)
+
+  instance$archive$push_failed_point(list(cp = 0.01), condition = list(message = "error"))
+
+  tab = as.data.table(instance$archive, measures = msr("classif.acc"))
+  expect_data_table(tab, min.rows = 6)
+  expect_true(is.na(tab[state == "failed", classif.acc]))
+  expect_numeric(tab[state == "finished", classif.acc], any.missing = FALSE)
+})
+
 test_that("ArchiveAsyncTuning as.data.table function works with empty archive", {
   rush = start_rush()
   on.exit({

--- a/tests/testthat/test_ArchiveAsyncTuningFrozen.R
+++ b/tests/testthat/test_ArchiveAsyncTuningFrozen.R
@@ -37,3 +37,31 @@ test_that("ArchiveAsyncTuningFrozen works", {
 
   expect_data_table(as.data.table(frozen_archive))
 })
+
+test_that("ArchiveAsyncTuningFrozen as.data.table function works with failed points", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 5),
+    store_benchmark_result = TRUE,
+    rush = rush
+  )
+  tuner = tnr("async_random_search")
+  tuner$optimize(instance)
+
+  instance$archive$push_failed_point(list(cp = 0.01), condition = list(message = "error"))
+  frozen_archive = ArchiveAsyncTuningFrozen$new(instance$archive)
+
+  tab = as.data.table(frozen_archive, measures = msr("classif.acc"))
+  expect_data_table(tab, min.rows = 6)
+  expect_true(is.na(tab[state == "failed", classif.acc]))
+  expect_numeric(tab[state == "finished", classif.acc], any.missing = FALSE)
+})


### PR DESCRIPTION
as.data.table.ArchiveAsyncTuning() and as.data.table.ArchiveAsyncTuningFrozen() errored with "attempt to apply non-function" when the measures argument was used on an archive containing queued, running, or failed points, because these points have no resample result. The extra measures are now NA for such points.

as.data.table.ArchiveAsyncTuning() also re-fetched the archive from Redis for the scores, which could misalign rows when tasks arrived between the two fetches. The scores are now computed on the already fetched snapshot.