### PR TITLE
fix: deep clone shared objects in AutoTuner clone

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `AutoTuner$clone(deep = TRUE)` now deep clones the wrapped learner, resampling, measure, terminator, callbacks, and the trained model. Previously, the clone shared these objects with the original, so for example setting the predict type on the clone also changed the original.
 
 # mlr3tuning 1.6.0
 

--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -441,7 +441,35 @@ AutoTuner = R6Class(
     .extract_internal_valid_scores = function() {
       self$model$learner$internal_valid_scores
     },
-    .store_tuning_instance = NULL
+    .store_tuning_instance = NULL,
+
+    deep_clone = function(name, value) {
+      if (name == "instance_args") {
+        # rush objects hold a data base connection and are shared between clones
+        map(value, function(x) {
+          if (inherits(x, "Rush")) {
+            x
+          } else if (inherits(x, "R6")) {
+            x$clone(deep = TRUE)
+          } else if (is.list(x)) {
+            map(x, function(element) if (inherits(element, "R6")) element$clone(deep = TRUE) else element)
+          } else {
+            x
+          }
+        })
+      } else if (name == "tuner") {
+        value$clone(deep = TRUE)
+      } else if (name == "state" && inherits(value$model, "auto_tuner_model")) {
+        value = super$deep_clone(name, value)
+        value$model$learner = value$model$learner$clone(deep = TRUE)
+        if (!is.null(value$model$tuning_instance)) {
+          value$model$tuning_instance = value$model$tuning_instance$clone(deep = TRUE)
+        }
+        value
+      } else {
+        super$deep_clone(name, value)
+      }
+    }
   )
 )
 

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -784,3 +784,45 @@ test_that("AutoTuner works with set_validate function", {
   set_validate(at, validate = NULL)
   expect_true(is.null(at$learner$validate))
 })
+
+test_that("AutoTuner deep clone does not share instance args", {
+  at = auto_tuner(
+    tuner = tnr("random_search", batch_size = 2),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("holdout"),
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+
+  at2 = at$clone(deep = TRUE)
+
+  expect_different_address(at$instance_args$learner, at2$instance_args$learner)
+  expect_different_address(at$instance_args$resampling, at2$instance_args$resampling)
+  expect_different_address(at$instance_args$measure, at2$instance_args$measure)
+  expect_different_address(at$instance_args$terminator, at2$instance_args$terminator)
+  expect_different_address(at$tuner, at2$tuner)
+
+  at2$predict_type = "prob"
+  expect_equal(at$instance_args$learner$predict_type, "response")
+  expect_equal(at$predict_type, "response")
+})
+
+test_that("AutoTuner deep clone does not share the trained model", {
+  at = auto_tuner(
+    tuner = tnr("random_search", batch_size = 2),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("holdout"),
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+  at$train(tsk("pima"))
+
+  at2 = at$clone(deep = TRUE)
+
+  expect_different_address(at$model$learner, at2$model$learner)
+  expect_different_address(at$model$tuning_instance, at2$model$tuning_instance)
+
+  at2$predict_type = "prob"
+  expect_equal(at$model$learner$predict_type, "response")
+  expect_equal(at$predict_type, "response")
+})


### PR DESCRIPTION
## Problem

`AutoTuner$clone(deep = TRUE)` shared mutable state with the original object.
`instance_args` is a plain list of R6 objects (learner, resampling, measure, terminator, callbacks), and R6's default deep clone does not descend into lists.
After `at2 = at$clone(deep = TRUE); at2$predict_type = "prob"`, the *original's* inner learner had `predict_type = "prob"` as well, because the `predict_type` setter writes through the shared reference.
Since mlr3 deep clones learners routinely (`resample()`, `benchmark_grid()`), this could corrupt sibling learners in ordinary benchmarks.
The trained model's learner and tuning instance were shared between clones, too.

## Fix

Implement a private `deep_clone` method that

- deep clones all R6 objects in `instance_args` (including the callbacks list; `rush` connections stay shared),
- deep clones the `tuner`, and
- deep clones the model's learner and tuning instance in the `state`,

delegating everything else to `Learner`'s `deep_clone`.

## Tests

Adds clone tests for both the untrained and the trained `AutoTuner` (there were none before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)