### PR TITLE
fix: do not modify stored tuning instance in extract_inner_tuning_results()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `extract_inner_tuning_results()` no longer modifies the result table of the stored tuning instances by reference. Previously, the `iteration` and `tuning_instance` columns were written into `instance$result`, and a stale `tuning_instance` column could leak into the output of a second call with `tuning_instance = FALSE`.
 
 # mlr3tuning 1.6.0
 

--- a/R/extract_inner_tuning_results.R
+++ b/R/extract_inner_tuning_results.R
@@ -71,7 +71,8 @@ extract_inner_tuning_results.ResampleResult = function(x, tuning_instance = FALS
     return(data.table())
   }
   tab = imap_dtr(rr$learners, function(learner, i) {
-    data = setalloccol(learner$tuning_result)
+    # copy to avoid modifying the result table of the tuning instance by reference
+    data = copy(learner$tuning_result)
     set(data, j = "iteration", value = i)
     if (tuning_instance) {
       set(data, j = "tuning_instance", value = list(learner$tuning_instance))

--- a/tests/testthat/test_extract_inner_tuning_results.R
+++ b/tests/testthat/test_extract_inner_tuning_results.R
@@ -287,3 +287,24 @@ test_that("extract_inner_tuning_results returns tuning_instance", {
   )
   expect_equal(unique(tab$experiment), c(1, 2))
 })
+
+test_that("extract_inner_tuning_results does not modify the tuning instance by reference", {
+  at = AutoTuner$new(
+    lrn("classif.rpart"),
+    rsmp("holdout"),
+    msr("classif.ce"),
+    trm("evals", n_evals = 4),
+    tuner = tnr("random_search"),
+    TEST_MAKE_PS1(n_dim = 1)
+  )
+  rr = resample(tsk("iris"), at, rsmp("cv", folds = 2), store_models = TRUE)
+
+  irr = extract_inner_tuning_results(rr, tuning_instance = TRUE)
+  expect_names(names(irr), must.include = c("iteration", "tuning_instance"))
+  expect_names(names(rr$learners[[1]]$tuning_result), disjunct.from = c("iteration", "tuning_instance"))
+  expect_names(names(rr$learners[[1]]$tuning_instance$result), disjunct.from = c("iteration", "tuning_instance"))
+
+  # no stale columns leak into a second call
+  irr = extract_inner_tuning_results(rr, tuning_instance = FALSE)
+  expect_names(names(irr), disjunct.from = "tuning_instance")
+})


### PR DESCRIPTION
## Problem

`extract_inner_tuning_results.ResampleResult()` corrupted the stored tuning instance by reference.
`learner$tuning_result` returns the instance's private `.result` data.table without a copy; `setalloccol()` + `set()` then wrote the `iteration` and `tuning_instance` columns straight into the stored result.
After one call, `rr$learners[[1]]$tuning_instance$result` gained both columns, and the instance's own result table embedded a self-reference to the instance.
A later call with `tuning_instance = FALSE` leaked the stale column into its output.

## Fix

Copy the result table before modifying it (`data = copy(learner$tuning_result)`).
The sibling `extract_inner_tuning_archives()` already avoids this by operating on a fresh `as.data.table()` result.

## Tests

Adds a regression test asserting that the stored tuning result stays untouched and that no stale column leaks into a second call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)