### PR TITLE
fix: use number of pareto points in multi-crit assign_result

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `TuningInstanceBatchMultiCrit$assign_result()` and `TuningInstanceAsyncMultiCrit$assign_result()` produced wrong `result_learner_param_vals` when the search space was empty, because the number of measures instead of the number of Pareto points was used to recycle the parameter values.
 
 # mlr3tuning 1.6.0
 

--- a/R/TuningInstanceAsyncMulticrit.R
+++ b/R/TuningInstanceAsyncMulticrit.R
@@ -166,7 +166,7 @@ TuningInstanceAsyncMultiCrit = R6Class(
 
       opt_x = transform_xdt_to_xss(private$.result_xdt, self$search_space)
       if (length(opt_x) == 0) {
-        opt_x = replicate(length(private$.result_ydt), list())
+        opt_x = replicate(nrow(private$.result_ydt), list())
       }
       private$.result_learner_param_vals = Map(insert_named, private$.result_learner_param_vals, opt_x)
 

--- a/R/TuningInstanceBatchMulticrit.R
+++ b/R/TuningInstanceBatchMulticrit.R
@@ -192,7 +192,7 @@ TuningInstanceBatchMultiCrit = R6Class(
 
       opt_x = transform_xdt_to_xss(private$.result_xdt, self$search_space)
       if (length(opt_x) == 0) {
-        opt_x = replicate(length(private$.result_ydt), list())
+        opt_x = replicate(nrow(private$.result_ydt), list())
       }
       private$.result_learner_param_vals = Map(insert_named, private$.result_learner_param_vals, opt_x)
 

--- a/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
@@ -71,6 +71,30 @@ test_that("assigning a result to TuningInstanceAsyncSingleCrit works", {
   expect_names(names(result), must.include = c("cp", "learner_param_vals", "x_domain", "classif.ce", "classif.acc"))
 })
 
+test_that("assign_result works with empty search space and front size not divisible by number of measures", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("holdout"),
+    measures = msrs(c("classif.ce", "classif.acc")),
+    terminator = trm("evals", n_evals = 10),
+    rush = rush
+  )
+
+  xdt = data.table(x_domain = list(list(), list(), list()))
+  ydt = data.table(classif.ce = c(0.3, 0.4, 0.5), classif.acc = c(0.7, 0.6, 0.5))
+  instance$assign_result(xdt, ydt)
+
+  expect_list(instance$result_learner_param_vals, len = 3)
+  expect_equal(instance$result_learner_param_vals[[1]], list(xval = 0))
+})
+
 test_that("saving the benchmark result with TuningInstanceRushSingleCrit works", {
   rush = start_rush()
   on.exit({

--- a/tests/testthat/test_TuningInstanceBatchMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchMultiCrit.R
@@ -194,6 +194,23 @@ test_that("TuningInstanceBatchMultiCrit and empty search space works", {
   expect_equal(instance$result$x_domain[[1]], list())
 })
 
+test_that("assign_result works with empty search space and front size not divisible by number of measures", {
+  instance = TuningInstanceBatchMultiCrit$new(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("holdout"),
+    measures = msrs(c("classif.ce", "classif.acc")),
+    terminator = trm("evals", n_evals = 10)
+  )
+
+  xdt = data.table(x_domain = list(list(), list(), list()))
+  ydt = data.table(classif.ce = c(0.3, 0.4, 0.5), classif.acc = c(0.7, 0.6, 0.5))
+  instance$assign_result(xdt, ydt)
+
+  expect_list(instance$result_learner_param_vals, len = 3)
+  expect_equal(instance$result_learner_param_vals[[1]], list(xval = 0))
+})
+
 # Internal Tuning --------------------------------------------------------------
 
 test_that("Batch multi-crit internal tuning works", {


### PR DESCRIPTION
## Problem

In the empty-search-space branch of `TuningInstance{Batch,Async}MultiCrit$assign_result()`:

```r
opt_x = replicate(length(private$.result_ydt), list())
```

`private$.result_ydt` is a data.table, so `length()` counts **columns (measures), not rows (Pareto points)**; the sibling branch six lines up correctly uses `nrow()`.
This branch is reachable whenever the primary search space is empty (all-internal tuning, constant configurations).
With a 3-point front and 2 measures, `Map(insert_named, ...)` recycles and produces wrong `result_learner_param_vals`.
The existing test passed only because 10 front points happened to be divisible by 2 measures.

## Fix

Use `nrow(private$.result_ydt)` in both the batch and the async class.

## Tests

Adds a direct `assign_result()` test with a 3-point front and 2 measures for both classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)