### PR TITLE
fix: guard ArchiveAsyncTuning benchmark_result access without stored benchmark result

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Minimum required version of `rush` is now 1.2.0.
   Removed all compatibility workarounds for older versions.
+* fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
 

--- a/R/ArchiveAsyncTuning.R
+++ b/R/ArchiveAsyncTuning.R
@@ -181,7 +181,11 @@ ArchiveAsyncTuning = R6Class(
     benchmark_result = function() {
       # cache benchmark result
       if (self$rush$n_finished_tasks > private$.benchmark_result$n_resample_results) {
-        bmrs = map(self$finished_data$resample_result, as_benchmark_result)
+        finished_data = self$finished_data
+        if ("resample_result" %nin% names(finished_data)) {
+          stopf("No benchmark result stored in the archive. Set `store_benchmark_result = TRUE`.")
+        }
+        bmrs = map(finished_data$resample_result, as_benchmark_result)
         private$.benchmark_result = Reduce(function(lhs, rhs) lhs$combine(rhs), bmrs)
       }
       private$.benchmark_result

--- a/R/ArchiveAsyncTuningFrozen.R
+++ b/R/ArchiveAsyncTuningFrozen.R
@@ -23,7 +23,12 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param archive ([ArchiveAsyncTuning])\cr
     #' The archive to freeze.
     initialize = function(archive) {
-      private$.benchmark_result = archive$benchmark_result
+      # accessing archive$benchmark_result errors when no benchmark result was stored
+      private$.benchmark_result = if ("resample_result" %in% names(archive$finished_data)) {
+        archive$benchmark_result
+      } else {
+        BenchmarkResult$new()
+      }
       private$.internal_search_space = archive$internal_search_space
       super$initialize(archive)
     },

--- a/tests/testthat/test_ArchiveAsyncTuning.R
+++ b/tests/testthat/test_ArchiveAsyncTuning.R
@@ -271,6 +271,36 @@ test_that("ArchiveAsyncTuning as.data.table function works without resample resu
   )
 })
 
+test_that("ArchiveAsyncTuning benchmark_result errors without stored benchmark result", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 5),
+    store_benchmark_result = FALSE,
+    rush = rush
+  )
+  tuner = tnr("async_random_search")
+  tuner$optimize(instance)
+
+  expect_error(instance$archive$benchmark_result, "store_benchmark_result")
+  # repeated access raises the same error instead of corrupting the cache
+  expect_error(instance$archive$benchmark_result, "store_benchmark_result")
+  expect_error(instance$archive$resample_result(1), "store_benchmark_result")
+
+  # freezing still works and returns an empty benchmark result
+  frozen = ArchiveAsyncTuningFrozen$new(instance$archive)
+  expect_benchmark_result(frozen$benchmark_result)
+  expect_equal(frozen$benchmark_result$n_resample_results, 0)
+})
+
 test_that("ArchiveAsyncTuning as.data.table function works with failed points", {
   rush = start_rush()
   on.exit({


### PR DESCRIPTION
## Problem

`ArchiveAsyncTuning$benchmark_result` permanently self-corrupted when the instance was created with `store_benchmark_result = FALSE` (a supported configuration).
With no `resample_result` column in the finished data, `map(NULL, as_benchmark_result)` is `list()` and `Reduce(...)` returns `NULL`, overwriting the cached `BenchmarkResult` with `NULL`.
The first access returned `NULL`; every later access died inside `if (n_finished_tasks > NULL)` with "argument is of length zero".
The corruption propagated into `ArchiveAsyncTuningFrozen$initialize` and thus the `mlr3tuning.async_freeze_archive` callback.

## Fix

- `ArchiveAsyncTuning$benchmark_result` guards on the existence of the `resample_result` column and raises a clear error pointing to `store_benchmark_result = TRUE`. The cache is never clobbered, so repeated access raises the same error.
- `ArchiveAsyncTuningFrozen$initialize` falls back to an empty `BenchmarkResult` when nothing was stored, so freezing such archives keeps working (matching the batch archive, which also holds an empty `BenchmarkResult` in this configuration).

## Tests

Adds a test with `store_benchmark_result = FALSE` that asserts the clear error on repeated access, the error from `resample_result()`, and that freezing still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)