### PR TITLE
fix: prevent one se rule callback crashes at result assignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `clbk("mlr3tuning.one_se_rule")` and `clbk("mlr3tuning.async_one_se_rule")` no longer crash at result assignment when the archive contains a single evaluation or points without a performance score (queued, running, or failed points). These points are now removed before the standard error is computed, so they no longer deflate the standard error.
 
 # mlr3tuning 1.6.0
 

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -388,6 +388,9 @@ load_callback_async_one_se_rule = function() {
       archive = context$instance$archive
       data = as.data.table(archive)
 
+      # remove queued, running, and failed points which have no performance score
+      data = data[!is.na(data[[archive$cols_y]])]
+
       # standard error
       if (!nrow(data)) {
         stopf("No data in archive")
@@ -396,7 +399,7 @@ load_callback_async_one_se_rule = function() {
       y = data[[archive$cols_y]]
       se = sd(y) / sqrt(length(y))
 
-      if (se == 0) {
+      if (is.na(se) || se == 0) {
         # select smallest feature set when all scores are the same
         best = data[which.min(get("n_features"))]
       } else {
@@ -444,11 +447,18 @@ load_callback_one_se_rule = function() {
       archive = context$instance$archive
       data = as.data.table(archive)
 
+      # remove failed points which have no performance score
+      data = data[!is.na(data[[archive$cols_y]])]
+
       # standard error
+      if (!nrow(data)) {
+        stopf("No data in archive")
+      }
+
       y = data[[archive$cols_y]]
       se = sd(y) / sqrt(length(y))
 
-      if (se == 0) {
+      if (is.na(se) || se == 0) {
         # select smallest feature set when all scores are the same
         best = data[which.min(get("n_features"))]
       } else {

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -509,6 +509,47 @@ test_that("one se rule callback works", {
   expect_numeric(instance$result$n_features)
 })
 
+test_that("one se rule callback works with a single evaluation", {
+  instance = tune(
+    tuner = tnr("random_search", batch_size = 1),
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
+    resampling = rsmp("holdout"),
+    measures = msr("classif.ce"),
+    term_evals = 1,
+    callbacks = clbk("mlr3tuning.one_se_rule")
+  )
+
+  expect_data_table(instance$result, nrows = 1)
+  expect_numeric(instance$result$n_features)
+})
+
+test_that("async one se rule callback works with a single evaluation", {
+  skip_if_not_installed("rush")
+  skip_if_no_redis()
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("holdout"),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 1),
+    callbacks = clbk("mlr3tuning.async_one_se_rule"),
+    rush = rush
+  )
+
+  tuner = tnr("async_random_search")
+  tuner$optimize(instance)
+
+  expect_data_table(instance$result, min.rows = 1)
+  expect_numeric(instance$result$n_features)
+})
+
 # async freeze archive callback ------------------------------------------------
 
 test_that("async freeze archive callback works", {

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -529,7 +529,7 @@ test_that("one se rule callback works", {
 test_that("one se rule callback works with a single evaluation", {
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -551,7 +551,7 @@ test_that("async one se rule callback works with a single evaluation", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),


### PR DESCRIPTION
## Problem

`clbk("mlr3tuning.async_one_se_rule")` crashed at result assignment on real async archives — *after* the entire tuning run, destroying the result:

- `as.data.table(archive)` for async archives includes queued/running/failed rows whose scores are `NA`; `se = sd(y) / sqrt(length(y))` is then `NA` (no `na.rm`) and `if (se == 0)` errors with "missing value where TRUE/FALSE needed". Leftover queued or running tasks at termination are the normal async case.
- A single-row archive crashes the same way in both the async and the batch variant (`sd()` of one value is `NA`).
- The batch twin lacked even the `!nrow(data)` guard.
- Even when it survived, `length(y)` counted `NA` rows and deflated the standard error.

## Fix

In both callbacks:

- filter out points without a performance score before computing the standard error,
- guard against an empty archive,
- treat an `NA` standard error (single evaluation) like `se == 0` and select the smallest feature set.

## Tests

Adds single-evaluation tests for both the batch and the async callback (the batch one crashed with "missing value where TRUE/FALSE needed" before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)