### PR TITLE
fix: restore irace param set after optimization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `tnr("irace")` destroyed its own configuration during `$optimize()` by removing `n_instances` from and writing instantiated resamplings into its param set, which made a second run of the same tuner or `AutoTuner` impossible. The param set is now restored after the run.
 
 # mlr3tuning 1.6.0
 

--- a/R/TunerBatchIrace.R
+++ b/R/TunerBatchIrace.R
@@ -118,16 +118,25 @@ TunerBatchIrace = R6Class(
       pv = self$param_set$values
       n_instances = pv$n_instances
 
+      # restore the shared param set after the run so a second optimize() works
+      on.exit(
+        {
+          private$.optimizer$param_set$values = pv
+        },
+        add = TRUE
+      )
+
       # Set resampling instances
       ri = replicate(n_instances, {
         r = inst$objective$resampling$clone()
         r$instantiate(inst$objective$task)
       })
 
-      pv$n_instances = NULL
-      pv$instances = ri
+      pv_run = pv
+      pv_run$n_instances = NULL
+      pv_run$instances = ri
 
-      private$.optimizer$param_set$values = pv
+      private$.optimizer$param_set$values = pv_run
 
       private$.optimizer$optimize(inst)
 

--- a/tests/testthat/test_TunerBatchIrace.R
+++ b/tests/testthat/test_TunerBatchIrace.R
@@ -22,6 +22,32 @@ test_that("TunerIrace", {
   expect_equal(unname(instance$result_y), mean(archive[configuration == configuration_id, classif.ce]))
 })
 
+test_that("TunerIrace can be run twice", {
+  tuner = tnr("irace")
+
+  new_instance = function() {
+    ti(
+      task = tsk("mtcars"),
+      learner = lrn("regr.rpart", cp = to_tune(0.001, 0.1)),
+      resampling = rsmp("holdout"),
+      measures = msr("regr.mse"),
+      terminator = trm("evals", n_evals = 42)
+    )
+  }
+
+  instance = new_instance()
+  suppressMessages(capture.output(tuner$optimize(instance)))
+  expect_data_table(instance$result, nrows = 1)
+
+  # param set is restored after the run
+  expect_equal(tuner$param_set$values$n_instances, 10)
+  expect_null(tuner$param_set$values$instances)
+
+  instance = new_instance()
+  suppressMessages(capture.output(tuner$optimize(instance)))
+  expect_data_table(instance$result, nrows = 1)
+})
+
 test_that("TunerIrace works with dependencies", {
   search_space = ps(
     cp = p_dbl(lower = 0.001, upper = 0.1),


### PR DESCRIPTION
## Problem

`TunerBatchIrace$optimize()` destroyed its own configuration: it deleted `n_instances` from and injected instantiated `Resampling` objects into the *live shared* param set (`private$.optimizer$param_set$values = pv`).
After one successful `optimize()`:

- `n_instances` was `NULL`,
- ten instantiated resamplings sat permanently in `$values$instances` (printed, serialized, hashed), and
- a second `optimize()` died with `invalid 'length' argument`.

This made training the same irace `AutoTuner` twice impossible.

## Fix

Build the run configuration on a local copy of the values and restore the original param set values with `on.exit()` (so restoration also happens when the run errors).

## Tests

Adds a test that runs the same tuner twice and asserts the param set is restored between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)