### PR TITLE
fix: assert number of custom resamplings matches configurations in ObjectiveTuningBatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `ObjectiveTuningBatch` now errors when the number of custom resamplings does not match the number of hyperparameter configurations. Previously, the resamplings were silently recycled, pairing configurations with the wrong resamplings.
 
 # mlr3tuning 1.6.0
 

--- a/R/ObjectiveTuningBatch.R
+++ b/R/ObjectiveTuningBatch.R
@@ -65,6 +65,13 @@ ObjectiveTuningBatch = R6Class(
       private$.xss = xss
 
       private$.design = if (length(resampling) > 1) {
+        if (length(resampling) != length(xss)) {
+          stopf(
+            "Number of custom resamplings (%i) must match the number of hyperparameter configurations (%i).",
+            length(resampling),
+            length(xss)
+          )
+        }
         param_values = map(xss, function(xs) list(xs))
         data.table(
           task = list(self$task),

--- a/tests/testthat/test_ObjectiveTuningBatch.R
+++ b/tests/testthat/test_ObjectiveTuningBatch.R
@@ -115,6 +115,24 @@ test_that("tuner can modify resampling", {
   expect_equal(rr$resampling$id, "holdout")
 })
 
+test_that("mismatched number of configurations and resamplings errors", {
+  instance = TuningInstanceBatchSingleCrit$new(
+    task = tsk("iris"),
+    learner = lrn("classif.rpart", cp = to_tune(0.001, 0.1)),
+    resampling = rsmp("cv", folds = 3),
+    measure = msr("classif.ce"),
+    terminator = trm("none")
+  )
+
+  resamplings = replicate(2, rsmp("holdout")$instantiate(tsk("iris")))
+  instance$objective$constants$values$resampling = resamplings
+
+  expect_error(
+    instance$eval_batch(data.table(cp = c(0.001, 0.01, 0.05, 0.1))),
+    "must match the number of hyperparameter configurations"
+  )
+})
+
 test_that("benchmark clone works", {
   grid = benchmark_grid(
     tasks = tsk("iris"),


### PR DESCRIPTION
## Problem

In the `length(resampling) > 1` branch of `ObjectiveTuningBatch$.eval_many()` (the custom-resampling extension point used by callbacks, `tnr("irace")`, and extension packages), the design paired `xss[[i]]` with `resampling[[i]]` with no length assertion.
With 4 configurations and 2 resamplings, data.table recycled the resamplings 1,2,1,2 with **no warning**, silently producing wrong archive entries.

## Fix

Error with a clear message when the number of custom resamplings does not match the number of hyperparameter configurations.

## Tests

Adds a test that sets two custom resamplings on the objective and evaluates a four-configuration batch, expecting the new error.
The irace tests (the main consumer of this branch) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)