### PR TITLE
fix: validate learner_param_vals in multi-crit assign_result

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `assign_result()` of `TuningInstanceBatchMultiCrit` and `TuningInstanceAsyncMultiCrit` now validates `learner_param_vals` like the single-crit instances.
 
 # mlr3tuning 1.6.0
 

--- a/R/TuningInstanceAsyncMulticrit.R
+++ b/R/TuningInstanceAsyncMulticrit.R
@@ -143,6 +143,9 @@ TuningInstanceAsyncMultiCrit = R6Class(
 
       call_back("on_tuning_result_begin", self$objective$callbacks, self$objective$context)
 
+      # check learner param_vals, one named list per point
+      assert_list(private$.result_learner_param_vals, types = "list", len = nrow(private$.result_ydt), null.ok = TRUE)
+
       # extract internal tuned values
       if ("internal_tuned_values" %in% names(private$.result_extra)) {
         set(

--- a/R/TuningInstanceBatchMulticrit.R
+++ b/R/TuningInstanceBatchMulticrit.R
@@ -169,6 +169,9 @@ TuningInstanceBatchMultiCrit = R6Class(
 
       call_back("on_tuning_result_begin", self$objective$callbacks, self$objective$context)
 
+      # check learner param_vals, one named list per point
+      assert_list(private$.result_learner_param_vals, types = "list", len = nrow(private$.result_ydt), null.ok = TRUE)
+
       # extract internal tuned values
       if ("internal_tuned_values" %in% names(private$.result_extra)) {
         set(

--- a/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
@@ -71,6 +71,29 @@ test_that("assigning a result to TuningInstanceAsyncSingleCrit works", {
   expect_names(names(result), must.include = c("cp", "learner_param_vals", "x_domain", "classif.ce", "classif.acc"))
 })
 
+test_that("assign_result checks learner_param_vals", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
+    resampling = rsmp("cv", folds = 3),
+    measures = msrs(c("classif.ce", "classif.acc")),
+    terminator = trm("evals", n_evals = 3),
+    rush = rush
+  )
+
+  xdt = data.table(cp = 0.05)
+  ydt = data.table(classif.ce = 0.1, classif.acc = 0.9)
+
+  expect_error(instance$assign_result(xdt, ydt, learner_param_vals = c("a", "b")), "list")
+  expect_error(instance$assign_result(xdt, ydt, learner_param_vals = list(list(), list())), "length 1")
+})
+
 test_that("saving the benchmark result with TuningInstanceRushSingleCrit works", {
   rush = start_rush()
   on.exit({

--- a/tests/testthat/test_TuningInstanceBatchMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchMultiCrit.R
@@ -147,6 +147,15 @@ test_that("TuneToken and result_learner_param_vals works", {
   expect_equal(instance$result_learner_param_vals[[1]]$cp, 0.1)
 })
 
+test_that("assign_result checks learner_param_vals", {
+  inst = TEST_MAKE_INST1_2D()
+  xdt = data.table(cp = 0.1)
+  ydt = data.table(classif.ce = 0.1, classif.acc = 0.9)
+
+  expect_error(inst$assign_result(xdt, ydt, learner_param_vals = c("a", "b")), "list")
+  expect_error(inst$assign_result(xdt, ydt, learner_param_vals = list(list(), list())), "length 1")
+})
+
 test_that("TuningInstanceBatchMultiCrit and empty search space works", {
   # xval constant
   instance = tune(


### PR DESCRIPTION
## Problem

Both single-crit `assign_result()` methods (`TuningInstanceBatchSingleCrit`, `TuningInstanceAsyncSingleCrit`) validate the `learner_param_vals` argument with `assert_list()`, but the multi-crit twins (`TuningInstanceBatchMultiCrit`, `TuningInstanceAsyncMultiCrit`) accepted it unchecked, despite the stricter contract (a list of named lists, one per Pareto point).

## Fix

Add `assert_list(private$.result_learner_param_vals, types = "list", len = nrow(private$.result_ydt), null.ok = TRUE)` to both multi-crit `assign_result()` methods, placed after the `on_tuning_result_begin` callback for consistency with the single-crit methods.

## Tests

New tests in `test_TuningInstanceBatchMultiCrit.R` and `test_TuningInstanceAsyncMultiCrit.R` verify that `assign_result()` errors on a plain character vector and on a list whose length does not match the number of points in `ydt`. Ran the multi-crit batch and async test suites plus `TuningInstanceBatchSingleCrit` for regressions; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)