### PR TITLE
fix: store unnamed n_features in async one se rule callback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `clbk("mlr3tuning.async_one_se_rule")` now stores an unnamed numeric in the `n_features` column of the archive, matching the batch callback.
 
 # mlr3tuning 1.6.0
 

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -378,7 +378,7 @@ load_callback_async_one_se_rule = function() {
 
     on_eval_before_archive = function(callback, context) {
       res = context$resample_result$aggregate(msr("selected_features"))
-      context$aggregated_performance$n_features = res
+      context$aggregated_performance$n_features = unname(res)
       if (!callback$state$store_models) {
         context$resample_result$discard(models = TRUE)
       }

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -506,6 +506,7 @@ test_that("one se rule callback works", {
   tuner$optimize(instance)
 
   expect_numeric(instance$archive$data$n_features)
+  expect_null(names(instance$archive$data$n_features))
   expect_numeric(instance$result$n_features)
 })
 


### PR DESCRIPTION
## Problem

In `load_callback_async_one_se_rule` (`R/mlr_callbacks.R`), the `on_eval_before_archive` stage stores `context$resample_result$aggregate(msr("selected_features"))` into `context$aggregated_performance$n_features`. The value returned by `aggregate()` is a *named* numeric, so the `n_features` column of the async archive ends up with names, while the batch twin (`mlr3tuning.one_se_rule`) stores a plain unnamed numeric.

## Fix

Unname the aggregated value before storing it, so the async callback matches the batch callback.

## Tests

Added an assertion to the async one se rule callback test in `tests/testthat/test_mlr_callbacks.R` that the `n_features` column is unnamed. `devtools::test(filter = '^mlr_callbacks')` passes with Redis available (168 passed, 0 failed).

Note: PR #535 (`fix/one-se-rule-crashes`) touches the same callbacks but in the `on_tuning_result_begin` stage — different hunks, no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)