### PR TITLE
fix: warn when measures argument is ignored in as.data.table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
+* fix: `as.data.table.ArchiveAsyncTuning()`, `as.data.table.ArchiveAsyncTuningFrozen()`, and `as.data.table.ArchiveBatchTuning()` now warn instead of silently ignoring the `measures` argument when no benchmark result is stored.
 
 # mlr3tuning 1.6.0
 

--- a/R/ArchiveAsyncTuning.R
+++ b/R/ArchiveAsyncTuning.R
@@ -213,6 +213,9 @@ as.data.table.ArchiveAsyncTuning = function(
 
   # add extra measures
   cols_y_extra = NULL
+  if (!is.null(measures) && is.null(tab$resample_result)) {
+    warningf("Ignoring `measures` because no resample results are stored. Set `store_benchmark_result = TRUE`.")
+  }
   if (!is.null(measures) && !is.null(tab$resample_result)) {
     measures = assert_measures(as_measures(measures), learner = x$learners(1)[[1]], task = x$resample_result(1)$task)
     cols_y_extra = map_chr(measures, "id")

--- a/R/ArchiveAsyncTuningFrozen.R
+++ b/R/ArchiveAsyncTuningFrozen.R
@@ -161,6 +161,9 @@ as.data.table.ArchiveAsyncTuningFrozen = function(
 
   # add extra measures
   cols_y_extra = NULL
+  if (!is.null(measures) && is.null(tab$resample_result)) {
+    warningf("Ignoring `measures` because no resample results are stored. Set `store_benchmark_result = TRUE`.")
+  }
   if (!is.null(measures) && !is.null(tab$resample_result)) {
     measures = assert_measures(as_measures(measures), learner = x$learners(1)[[1]], task = x$resample_result(1)$task)
     cols_y_extra = map_chr(measures, "id")

--- a/R/ArchiveBatchTuning.R
+++ b/R/ArchiveBatchTuning.R
@@ -215,6 +215,9 @@ as.data.table.ArchiveBatchTuning = function(
   tab = unnest(data, cols, prefix = "{col}_")
 
   cols_y_extra = NULL
+  if (!is.null(measures) && !x$benchmark_result$n_resample_results) {
+    warningf("Ignoring `measures` because no benchmark result is stored. Set `store_benchmark_result = TRUE`.")
+  }
   if (x$benchmark_result$n_resample_results) {
     # add extra measures
     if (!is.null(measures)) {

--- a/tests/testthat/test_ArchiveAsyncTuning.R
+++ b/tests/testthat/test_ArchiveAsyncTuning.R
@@ -269,6 +269,15 @@ test_that("ArchiveAsyncTuning as.data.table function works without resample resu
       "condition"
     )
   )
+
+  # measures are ignored without resample results
+  expect_warning(
+    {
+      tab = as.data.table(instance$archive, measures = msr("classif.acc"))
+    },
+    "store_benchmark_result"
+  )
+  expect_false("classif.acc" %in% names(tab))
 })
 
 test_that("ArchiveAsyncTuning as.data.table function works with failed points", {

--- a/tests/testthat/test_ArchiveAsyncTuningFrozen.R
+++ b/tests/testthat/test_ArchiveAsyncTuningFrozen.R
@@ -38,6 +38,37 @@ test_that("ArchiveAsyncTuningFrozen works", {
   expect_data_table(as.data.table(frozen_archive))
 })
 
+test_that("ArchiveAsyncTuningFrozen as.data.table function works without resample result", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = ti_async(
+    task = tsk("pima"),
+    learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 20),
+    store_benchmark_result = FALSE,
+    rush = rush
+  )
+  tuner = tnr("async_random_search")
+  tuner$optimize(instance)
+
+  frozen_archive = ArchiveAsyncTuningFrozen$new(instance$archive)
+
+  # measures are ignored without resample results
+  expect_warning(
+    {
+      tab = as.data.table(frozen_archive, measures = msr("classif.acc"))
+    },
+    "store_benchmark_result"
+  )
+  expect_false("classif.acc" %in% names(tab))
+})
+
 test_that("ArchiveAsyncTuningFrozen as.data.table function works with failed points", {
   rush = start_rush()
   on.exit({

--- a/tests/testthat/test_ArchiveBatchTuning.R
+++ b/tests/testthat/test_ArchiveBatchTuning.R
@@ -286,6 +286,15 @@ test_that("ArchiveTuning as.data.table function works", {
     )
   )
 
+  # measures are ignored without benchmark result
+  expect_warning(
+    {
+      tab = as.data.table(instance$archive, measures = msr("classif.acc"))
+    },
+    "store_benchmark_result"
+  )
+  expect_false("classif.acc" %in% names(tab))
+
   # empty archive
   instance = ti(
     task = tsk("pima"),


### PR DESCRIPTION
## Problem

`as.data.table(archive, measures = ...)` **silently ignored** the requested measures when no benchmark result was stored, in all three archive variants (`ArchiveBatchTuning`, `ArchiveAsyncTuning`, `ArchiveAsyncTuningFrozen`): no column, no warning.

## Fix

All three `as.data.table()` methods now warn that `measures` is ignored and point to `store_benchmark_result = TRUE` when scoring is impossible. The returned table is unchanged.

## Tests

Adds `expect_warning` tests for all three variants with `store_benchmark_result = FALSE`.

Note: PR #534 (fix/archive-async-benchmark-result) touches `ArchiveAsyncTuning.R`/`ArchiveAsyncTuningFrozen.R` in different hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)