### PR TITLE
refactor: use get_private<- setter in tuning contexts

### DIFF
--- a/R/ContextAsyncTuning.R
+++ b/R/ContextAsyncTuning.R
@@ -23,7 +23,7 @@ ContextAsyncTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.xs
       } else {
-        self$instance$objective$.__enclos_env__$private$.xs = rhs
+        get_private(self$instance$objective, ".xs") = rhs
       }
     },
 
@@ -33,7 +33,7 @@ ContextAsyncTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.resample_result
       } else {
-        self$instance$objective$.__enclos_env__$private$.resample_result = rhs
+        get_private(self$instance$objective, ".resample_result") = rhs
       }
     },
 
@@ -45,7 +45,7 @@ ContextAsyncTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.aggregated_performance
       } else {
-        self$instance$objective$.__enclos_env__$private$.aggregated_performance = rhs
+        get_private(self$instance$objective, ".aggregated_performance") = rhs
       }
     },
 
@@ -55,7 +55,7 @@ ContextAsyncTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance)$.result_learner_param_vals
       } else {
-        self$instance$.__enclos_env__$private$.result_learner_param_vals = rhs
+        get_private(self$instance, ".result_learner_param_vals") = rhs
       }
     }
   )

--- a/R/ContextBatchTuning.R
+++ b/R/ContextBatchTuning.R
@@ -21,7 +21,7 @@ ContextBatchTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.xss
       } else {
-        self$instance$objective$.__enclos_env__$private$.xss = rhs
+        get_private(self$instance$objective, ".xss") = rhs
       }
     },
 
@@ -31,7 +31,7 @@ ContextBatchTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.design
       } else {
-        self$instance$objective$.__enclos_env__$private$.design = rhs
+        get_private(self$instance$objective, ".design") = rhs
       }
     },
 
@@ -41,7 +41,7 @@ ContextBatchTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.benchmark_result
       } else {
-        self$instance$objective$.__enclos_env__$private$.benchmark_result = rhs
+        get_private(self$instance$objective, ".benchmark_result") = rhs
       }
     },
 
@@ -53,7 +53,7 @@ ContextBatchTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance$objective)$.aggregated_performance
       } else {
-        self$instance$objective$.__enclos_env__$private$.aggregated_performance = rhs
+        get_private(self$instance$objective, ".aggregated_performance") = rhs
       }
     },
 
@@ -63,7 +63,7 @@ ContextBatchTuning = R6Class(
       if (missing(rhs)) {
         get_private(self$instance)$.result_learner_param_vals
       } else {
-        self$instance$.__enclos_env__$private$.result_learner_param_vals = rhs
+        get_private(self$instance, ".result_learner_param_vals") = rhs
       }
     }
   )


### PR DESCRIPTION
## Problem

The active binding setters in `ContextAsyncTuning` and `ContextBatchTuning` poked private fields directly via `self$instance$objective$.__enclos_env__$private$... = rhs` (nine occurrences across the two files), while the corresponding getters already use `get_private()` from mlr3misc.

## Fix

Replace every direct `$.__enclos_env__$private$X = value` assignment with the `get_private<-` setter exported by mlr3misc, e.g. `get_private(self$instance$objective, ".xs") = rhs`. This is a pure internal refactor with identical behavior, so no NEWS bullet is added.

## Tests

- `devtools::test(filter = 'Callback')` with `RUSH_TEST_USE_REDIS=true`: 83 passing, 0 failures
- `devtools::test(filter = 'mlr_callbacks')`: 167 passing, 0 failures
- No dedicated `Context` test files exist; the callback stage tests exercise the context setters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)