### PR TITLE
docs: fix grid search hotstart claim in mlr_tuners_grid_search

### DIFF
--- a/R/TunerBatchGridSearch.R
+++ b/R/TunerBatchGridSearch.R
@@ -8,8 +8,7 @@
 #' @details
 #' The grid is constructed as a Cartesian product over discretized values per parameter,
 #' see [paradox::generate_design_grid()].
-#' If the learner supports hotstarting, the grid is sorted by the hotstart parameter (see also [mlr3::HotstartStack]).
-#' If not, the points of the grid are evaluated in a random order.
+#' The points of the grid are evaluated in a random order.
 #'
 #' @templateVar id grid_search
 #' @template section_dictionary_tuners

--- a/man/mlr_tuners_grid_search.Rd
+++ b/man/mlr_tuners_grid_search.Rd
@@ -10,8 +10,7 @@ Subclass for grid search tuning.
 \details{
 The grid is constructed as a Cartesian product over discretized values per parameter,
 see \code{\link[paradox:generate_design_grid]{paradox::generate_design_grid()}}.
-If the learner supports hotstarting, the grid is sorted by the hotstart parameter (see also \link[mlr3:HotstartStack]{mlr3::HotstartStack}).
-If not, the points of the grid are evaluated in a random order.
+The points of the grid are evaluated in a random order.
 }
 \section{Dictionary}{
 


### PR DESCRIPTION
## What

Fixes the **Hotstarting** item from the "Copy-paste drift between the Batch/Async twins" section of the code review — the only sub-item there without an existing PR.

The `mlr_tuners_grid_search` details section claimed:

> If the learner supports hotstarting, the grid is sorted by the hotstart parameter (see also `mlr3::HotstartStack`).
> If not, the points of the grid are evaluated in a random order.

This is false. Batch grid search does not hotstart (hotstarting was deliberately removed from the batch path because it is inefficient), and bbotk's `OptimizerBatchGridSearch` always evaluates the grid points in a random order regardless of the learner. The doc now simply states that the points of the grid are evaluated in a random order.

## Why the code was left unchanged

The review flagged the async objective's hardcoded `allow_hotstart = TRUE` (`ObjectiveTuningAsync.R`) versus the batch objective never enabling it as drift. Per the maintainer, this is **intentional**: hotstarting works on the async path but was removed from the batch path because it is inefficient. Only the grid-search documentation was wrong, so this PR touches docs only.

## Notes

- No `NEWS.md` bullet: this is a small documentation-only change.
- `man/mlr_tuners_grid_search.Rd` regenerated via `devtools::document()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)