### PR TITLE
fix: include predict_sets, validate, and use_weights in AutoTuner$hash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   Removed all compatibility workarounds for older versions.
 * fix: `ArchiveBatchTuning$print()` no longer prints the archive table twice.
 * fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
+* fix: `AutoTuner$hash` now also depends on the `predict_sets`, `validate`, and `use_weights` settings so that autotuners differing only in these fields no longer share a hash.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.
   The extra measures are `NA` for these points.
 * `callback_async_tuning()` and `callback_batch_tuning()` remove the deprecated `on_result` stage.

--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -357,6 +357,10 @@ AutoTuner = R6Class(
         private$.predict_type,
         self$fallback$hash,
         self$parallel_predict,
+        get0("validate", self),
+        self$predict_sets,
+        private$.use_weights,
+        private$.predict_raw,
         self$tuner,
         self$instance_args,
         private$.store_tuning_instance

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -460,6 +460,27 @@ test_that("AutoTuner hash works #647 in mlr3", {
   )
 })
 
+test_that("AutoTuner hash reacts to predict_sets, validate and use_weights", {
+  new_at = function() {
+    AutoTuner$new(
+      learner = lrn("classif.rpart", minsplit = to_tune(1, 12)),
+      resampling = rsmp("holdout"),
+      measure = msr("classif.ce"),
+      terminator = trm("evals", n_evals = 4),
+      tuner = tnr("grid_search", resolution = 3)
+    )
+  }
+
+  at = new_at()
+  at_predict_sets = new_at()
+  at_predict_sets$predict_sets = c("train", "test")
+  expect_true(at$hash != at_predict_sets$hash)
+
+  at_use_weights = new_at()
+  at_use_weights$use_weights = "ignore"
+  expect_true(at$hash != at_use_weights$hash)
+})
+
 test_that("AutoTuner works with empty search space", {
   at = auto_tuner(
     tuner = tnr("random_search", batch_size = 5),


### PR DESCRIPTION
## Problem

`AutoTuner$hash` omitted the `predict_sets`, `validate`, and `use_weights` settings that the base `Learner$hash` includes. Two autotuners differing only in these fields shared a hash:

```r
mk = function() auto_tuner(tuner = tnr("random_search"),
  learner = lrn("classif.rpart", cp = to_tune(0.001, 0.1)),
  resampling = rsmp("holdout"), measure = msr("classif.ce"), term_evals = 2)
at1 = mk(); at2 = mk(); at2$predict_sets = c("train", "test")
at1$hash == at2$hash  # TRUE -> benchmark deduplication collides them
```

## Fix

Add `get0("validate", self)`, `self$predict_sets`, `private$.use_weights`, and `private$.predict_raw` to the hash calculation, mirroring `mlr3::Learner$hash`.

## Test

Added a regression test asserting the hash reacts to `predict_sets` and `use_weights`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)