### PR TITLE
fix: correct AutoTuner marshaling contract

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Minimum required version of `rush` is now 1.2.0.
   Removed all compatibility workarounds for older versions.
+* fix: `AutoTuner$marshaled` is now an active binding as in `mlr3::Learner`, so `at$marshaled` returns a flag instead of a method and can be used in conditions.
+* fix: Unmarshaling an `AutoTuner` model with `inplace = TRUE` after a non-inplace marshal no longer drops the `auto_tuner_model` class, which had caused a subsequent marshal to become a no-op.
 * fix: `ArchiveBatchTuning$print()` no longer prints the archive table twice.
 * fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.

--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -291,15 +291,16 @@ AutoTuner = R6Class(
     #' @return self
     unmarshal = function(...) {
       learner_unmarshal(.learner = self, ...)
-    },
-    #' @description
-    #' Whether the learner is marshaled.
-    marshaled = function() {
-      learner_marshaled(self)
     }
   ),
 
   active = list(
+    #' @field marshaled (`logical(1)`)\cr
+    #' Whether the learner has been marshaled.
+    marshaled = function() {
+      learner_marshaled(self)
+    },
+
     #' @field archive [ArchiveBatchTuning]\cr
     #' Archive of the [TuningInstanceBatchSingleCrit].
     archive = function() self$tuning_instance$archive,
@@ -518,7 +519,7 @@ unmarshal_model.auto_tuner_model_marshaled = function(model, inplace = FALSE, ..
   if (inplace) {
     at_model = model$marshaled
     at_model$learner$model = unmarshal_model(at_model$learner$model, inplace = TRUE)
-    return(at_model)
+    return(structure(at_model, class = c("auto_tuner_model", "list")))
   }
 
   at_model = model$marshaled

--- a/man/AutoTuner.Rd
+++ b/man/AutoTuner.Rd
@@ -170,6 +170,9 @@ Optimization algorithm.}
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
+    \item{\code{marshaled}}{(\code{logical(1)})\cr
+Whether the learner has been marshaled.}
+
     \item{\code{archive}}{\link{ArchiveBatchTuning}\cr
 Archive of the \link{TuningInstanceBatchSingleCrit}.}
 
@@ -211,7 +214,6 @@ during tuning (parameter values) or feature selection (feature names).}
     \item \href{#method-AutoTuner-print}{\code{AutoTuner$print()}}
     \item \href{#method-AutoTuner-marshal}{\code{AutoTuner$marshal()}}
     \item \href{#method-AutoTuner-unmarshal}{\code{AutoTuner$unmarshal()}}
-    \item \href{#method-AutoTuner-marshaled}{\code{AutoTuner$marshaled()}}
     \item \href{#method-AutoTuner-clone}{\code{AutoTuner$clone()}}
   }
 }
@@ -437,18 +439,6 @@ Additional parameters.}
   }
   \subsection{Returns}{
     self
-  }
-}
-
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-AutoTuner-marshaled"></a>}}
-\if{latex}{\out{\hypertarget{method-AutoTuner-marshaled}{}}}
-\subsection{\code{AutoTuner$marshaled()}}{
-  Whether the learner is marshaled.
-  \subsection{Usage}{
-    \if{html}{\out{<div class="r">}}
-    \preformatted{AutoTuner$marshaled()}
-    \if{html}{\out{</div>}}
   }
 }
 

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -699,6 +699,42 @@ test_that("marshal", {
   expect_class(model1, "marshaled")
 })
 
+test_that("marshaled is an active binding", {
+  at = auto_tuner(
+    tuner = tnr("random_search", batch_size = 2),
+    learner = lrn("classif.debug"),
+    resampling = rsmp("cv", folds = 3),
+    measure = msr("classif.ce"),
+    term_evals = 4
+  )
+  at$train(tsk("iris"))
+  # accessed as a field, not a method, and usable in a condition
+  expect_flag(at$marshaled)
+  expect_false(at$marshaled)
+  at$marshal()
+  expect_true(at$marshaled)
+  at$unmarshal()
+  expect_false(at$marshaled)
+})
+
+test_that("mixed-inplace marshal roundtrip keeps auto_tuner_model class", {
+  at = auto_tuner(
+    tuner = tnr("random_search", batch_size = 2),
+    learner = lrn("classif.debug"),
+    resampling = rsmp("cv", folds = 3),
+    measure = msr("classif.ce"),
+    term_evals = 4
+  )
+  at$train(tsk("iris"))
+  model = at$model
+
+  # non-inplace marshal followed by inplace unmarshal
+  roundtrip = unmarshal_model(marshal_model(model, inplace = FALSE), inplace = TRUE)
+  expect_class(roundtrip, "auto_tuner_model")
+  # a subsequent marshal still dispatches to the auto_tuner_model method
+  expect_class(marshal_model(roundtrip), "auto_tuner_model_marshaled")
+})
+
 # Async ------------------------------------------------------------------------
 
 test_that("AutoTuner works with async tuner", {


### PR DESCRIPTION
## Problems

Two marshaling contract violations in `AutoTuner`:

1. **`marshaled` was a public method** while the mlr3 ecosystem (and `mlr3::Learner`) exposes it as a logical active binding. `at$marshaled` returned the function object, and `if (learner$marshaled)` errored for `AutoTuner` only:

   ```r
   at$marshaled  # <function> instead of a flag
   if (at$marshaled) {}  # Error: argument is not interpretable as logical
   ```

2. **Mixed-`inplace` unmarshal dropped the model class.** `unmarshal_model.auto_tuner_model_marshaled(inplace = TRUE)` returned the model without re-adding the `auto_tuner_model` class. After a non-inplace marshal followed by an inplace unmarshal, the class was lost and a subsequent `marshal_model()` dispatched to the no-op default:

   ```r
   um = unmarshal_model(marshal_model(model, inplace = FALSE), inplace = TRUE)
   inherits(um, "auto_tuner_model")  # FALSE
   ```

## Fix

- Move `marshaled` from a public method to an active binding, matching `mlr3::Learner`.
- Re-add `class = c("auto_tuner_model", "list")` in the inplace unmarshal branch, matching the non-inplace branch.

## Tests

Added regression tests for the active binding and the mixed-inplace roundtrip class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)