### PR TITLE
fix: check instantiated inner resampling for all resampling types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Minimum required version of `rush` is now 1.2.0.
   Removed all compatibility workarounds for older versions.
+* fix: `AutoTuner$train()` now correctly checks that an instantiated inner resampling only uses row ids present in the task for all resampling types. Previously, the check read list-based instances and silently did nothing for resamplings such as `cv` and `holdout`.
 * fix: `ArchiveBatchTuning$print()` no longer prints the archive table twice.
 * fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.

--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -382,30 +382,35 @@ AutoTuner = R6Class(
       learner = ia$learner$clone(deep = TRUE)
 
       # check if task contains all row ids required for instantiated resampling
+      # we access the sets via train_set()/test_set() so the check also works for
+      # resamplings that do not store list-based instances (e.g. cv, holdout)
       if (ia$resampling$is_instantiated) {
-        imap(ia$resampling$instance$train, function(x, i) {
-          if (!test_subset(x, task$row_ids)) {
+        iters = seq_len(ia$resampling$iters)
+        for (i in iters) {
+          train_set = ia$resampling$train_set(i)
+          if (!test_subset(train_set, task$row_ids)) {
             stopf(
               "Train set %i of inner resampling '%s' contains row ids not present in task '%s': {%s}",
               i,
               ia$resampling$id,
               task$id,
-              paste(setdiff(x, task$row_ids), collapse = ", ")
+              paste(setdiff(train_set, task$row_ids), collapse = ", ")
             )
           }
-        })
+        }
 
-        imap(ia$resampling$instance$test, function(x, i) {
-          if (!test_subset(x, task$row_ids)) {
+        for (i in iters) {
+          test_set = ia$resampling$test_set(i)
+          if (!test_subset(test_set, task$row_ids)) {
             stopf(
               "Test set %i of inner resampling '%s' contains row ids not present in task '%s': {%s}",
               i,
               ia$resampling$id,
               task$id,
-              paste(setdiff(x, task$row_ids), collapse = ", ")
+              paste(setdiff(test_set, task$row_ids), collapse = ", ")
             )
           }
-        })
+        }
       }
 
       TuningInstance = if (inherits(self$tuner, "TunerBatch")) {

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -566,6 +566,25 @@ test_that("AutoTuner works with instantiated resampling", {
   expect_data_table(at$tuning_instance$result, nrows = 1)
 })
 
+test_that("AutoTuner checks instantiated cv resampling row ids", {
+  learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE))
+  task = tsk("penguins")
+
+  resampling_inner = rsmp("cv", folds = 3)
+  resampling_inner$instantiate(task)
+
+  at = auto_tuner(
+    tuner = tnr("random_search"),
+    learner = learner,
+    resampling = resampling_inner,
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+
+  # training on a strict subset leaves inner row ids outside the task
+  expect_error(at$train(task, row_ids = 1:50), "set [0-9]+ of inner resampling 'cv'")
+})
+
 test_that("AutoTuner errors when train set is not a subset of task ids", {
   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE))
   task = tsk("penguins")


### PR DESCRIPTION
## Problem

The `AutoTuner` guards against an instantiated inner resampling that references row ids missing from the (subset) task. The check read the list-based `resampling$instance$train`/`$test`, which only exist for custom and holdout resamplings. For resamplings such as `cv` the instance is a `data.table`, so `imap(NULL, ...)` iterated zero times and the friendly error never fired:

```r
r = rsmp("cv", folds = 3); r$instantiate(tsk("penguins"))
is.null(r$instance$train)  # TRUE -> check was dead
```

## Fix

Iterate over `seq_len(resampling$iters)` and read the sets via `resampling$train_set(i)` / `resampling$test_set(i)`, which work for every resampling type. The original error ordering (all train sets, then all test sets) is preserved.

## Test

Added a regression test asserting an instantiated `cv` inner resampling errors when trained on a strict subset of the task. The existing custom-resampling error tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)