### PR TITLE
fix: reject rush controller with a batch tuner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Minimum required version of `rush` is now 1.2.0.
   Removed all compatibility workarounds for older versions.
-* fix: `auto_tuner()`, `AutoTuner$new()`, and `tune()` now error at construction when a `rush` controller is supplied together with a batch tuner. Previously, `AutoTuner` failed with a confusing error at `$train()` and `tune()` silently ignored the `rush` argument.
+* fix: `auto_tuner()`, `AutoTuner$new()`, and `tune()` now error at construction when a `rush` controller is supplied together with a batch tuner.
 * fix: `ArchiveBatchTuning$print()` no longer prints the archive table twice.
 * fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Minimum required version of `rush` is now 1.2.0.
   Removed all compatibility workarounds for older versions.
+* fix: `auto_tuner()`, `AutoTuner$new()`, and `tune()` now error at construction when a `rush` controller is supplied together with a batch tuner. Previously, `AutoTuner` failed with a confusing error at `$train()` and `tune()` silently ignored the `rush` argument.
 * fix: `ArchiveBatchTuning$print()` no longer prints the archive table twice.
 * fix: `ArchiveAsyncTuning$benchmark_result` now raises a clear error when the tuning instance was created with `store_benchmark_result = FALSE`. Previously, the first access overwrote the cached benchmark result with `NULL` and every later access failed with an unrelated error. Freezing such an archive with `ArchiveAsyncTuningFrozen` works now and returns an empty benchmark result.
 * fix: `as.data.table.ArchiveAsyncTuning()` and `as.data.table.ArchiveAsyncTuningFrozen()` no longer error when the `measures` argument is used on an archive that contains queued, running, or failed points.

--- a/R/AutoTuner.R
+++ b/R/AutoTuner.R
@@ -173,6 +173,12 @@ AutoTuner = R6Class(
       ia$check_values = assert_flag(check_values)
       ia$callbacks = assert_callbacks(as_callbacks(callbacks))
       if (!is.null(rush)) {
+        if (!inherits(self$tuner, "TunerAsync")) {
+          stopf(
+            "A `rush` controller can only be used with an asynchronous tuner (`TunerAsync`), not with '%s'.",
+            class(self$tuner)[1L]
+          )
+        }
         ia$rush = assert_class(rush, "Rush")
       }
       self$instance_args = ia

--- a/R/tune.R
+++ b/R/tune.R
@@ -97,6 +97,12 @@ tune = function(
   rush = NULL
 ) {
   assert_tuner(tuner)
+  if (!is.null(rush) && !inherits(tuner, "TunerAsync")) {
+    stopf(
+      "A `rush` controller can only be used with an asynchronous tuner (`TunerAsync`), not with '%s'.",
+      class(tuner)[1L]
+    )
+  }
   terminator = terminator %??% terminator_selection(term_evals, term_time)
 
   instance = if (inherits(tuner, "TunerAsync")) {

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -725,6 +725,25 @@ test_that("AutoTuner works with async tuner", {
   expect_data_table(at$tuning_instance$archive$data, min.rows = 4)
 })
 
+test_that("AutoTuner errors when rush is used with a batch tuner", {
+  skip_if_not_installed("rush")
+  skip_if_no_redis()
+  rush = rush::rsh()
+  on.exit(rush$reset())
+
+  expect_error(
+    auto_tuner(
+      tuner = tnr("random_search"),
+      learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
+      resampling = rsmp("holdout"),
+      measure = msr("classif.ce"),
+      term_evals = 4,
+      rush = rush
+    ),
+    "asynchronous tuner"
+  )
+})
+
 # Internal Tuning --------------------------------------------------------------
 
 test_that("AutoTuner works with internal tuning and validation", {

--- a/tests/testthat/test_tune.R
+++ b/tests/testthat/test_tune.R
@@ -14,6 +14,26 @@ test_that("tune function works with one measure", {
   expect_class(instance$terminator, "TerminatorEvals")
 })
 
+test_that("tune errors when rush is used with a batch tuner", {
+  skip_if_not_installed("rush")
+  skip_if_no_redis()
+  rush = rush::rsh()
+  on.exit(rush$reset())
+
+  expect_error(
+    tune(
+      tuner = tnr("random_search", batch_size = 1),
+      task = tsk("pima"),
+      learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
+      resampling = rsmp("holdout"),
+      measures = msr("classif.ce"),
+      term_evals = 2,
+      rush = rush
+    ),
+    "asynchronous tuner"
+  )
+})
+
 test_that("tune function works with multiple measures", {
   learner = lrn("classif.rpart", minsplit = to_tune(1, 10))
   instance = tune(


### PR DESCRIPTION
## Problem

A `rush` controller only applies to asynchronous tuners (`TunerAsync`). The combination with a batch tuner was accepted at construction and failed later, or silently ignored:

```r
# AutoTuner: accepted, then dies at $train()
at = auto_tuner(tuner = tnr("random_search"), ..., rush = rush::rsh())
at$train(task)   # Error: unused argument (rush = <environment>)

# tune(): rush silently dropped on the batch path
tune(tuner = tnr("random_search"), ..., rush = rush::rsh())   # ran without rush
```

## Fix

`AutoTuner$new()` (and thus `auto_tuner()`) and `tune()` now check the combination up front and raise a clear error when `rush` is supplied with a non-`TunerAsync` tuner.

## Tests

Added regression tests for both `auto_tuner()` and `tune()` (gated on `rush` + redis like the other async tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)