### PR TITLE
docs: fix documentation that contradicts the code

### DIFF
--- a/R/ArchiveAsyncTuning.R
+++ b/R/ArchiveAsyncTuning.R
@@ -19,18 +19,17 @@
 #' * `runtime_learners` (`numeric(1)`)\cr
 #'     Sum of training and predict times logged in learners per [mlr3::ResampleResult] / evaluation.
 #'     This does not include potential overhead time.
-#' * `timestamp` (`POSIXct`)\cr
-#'     Time stamp when the evaluation was logged into the archive.
-#' * `batch_nr` (`integer(1)`)\cr
-#'     Hyperparameters are evaluated in batches.
-#'     Each batch has a unique batch number.
+#' * `timestamp_xs` (`POSIXct`)\cr
+#'     Time stamp when the hyperparameter configuration was sent to a worker.
+#' * `timestamp_ys` (`POSIXct`)\cr
+#'     Time stamp when the evaluation result was written to the archive.
 #'
 #' @section Analysis:
 #' For analyzing the tuning results, it is recommended to pass the [ArchiveAsyncTuning] to `as.data.table()`.
 #' The returned data table contains the [mlr3::ResampleResult] for each hyperparameter evaluation.
 #'
 #' @section S3 Methods:
-#' * `as.data.table.ArchiveTuning(x, unnest = "x_domain", exclude_columns = "uhash", measures = NULL)`\cr
+#' * `as.data.table.ArchiveAsyncTuning(x, unnest = "internal_tuned_values", exclude_columns = NULL, measures = NULL)`\cr
 #' Returns a tabular view of all evaluated hyperparameter configurations.\cr
 #' [ArchiveAsyncTuning] -> [data.table::data.table()]\cr
 #'     * `x` ([ArchiveAsyncTuning])
@@ -53,9 +52,6 @@ ArchiveAsyncTuning = R6Class(
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    #'
-    #' @param check_values (`logical(1)`)\cr
-    #'   If `TRUE` (default), hyperparameter configurations are checked for validity.
     initialize = function(
       search_space,
       codomain,
@@ -83,7 +79,7 @@ ArchiveAsyncTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learner
@@ -96,7 +92,7 @@ ArchiveAsyncTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learners = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learners
@@ -109,7 +105,7 @@ ArchiveAsyncTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner_param_vals = function(i = NULL, uhash = NULL) {
       self$learner(i = i, uhash = uhash)$param_set$values
@@ -122,7 +118,7 @@ ArchiveAsyncTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     predictions = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$predictions()
@@ -135,7 +131,7 @@ ArchiveAsyncTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     resample_result = function(i = NULL, uhash = NULL) {
       self$benchmark_result$resample_result(i = i, uhash = uhash)

--- a/R/ArchiveAsyncTuningFrozen.R
+++ b/R/ArchiveAsyncTuningFrozen.R
@@ -10,7 +10,7 @@
 #' * `as.data.table(archive)`\cr
 #'   [ArchiveAsyncTuningFrozen] -> [data.table::data.table()]\cr
 #'   Returns a tabular view of all performed function calls of the Objective.
-#'   The `x_domain` column is unnested to separate columns.
+#'   The `internal_tuned_values` column is unnested to separate columns.
 #'
 #' @export
 ArchiveAsyncTuningFrozen = R6Class(
@@ -41,7 +41,7 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learner
@@ -54,7 +54,7 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learners = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learners
@@ -67,7 +67,7 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner_param_vals = function(i = NULL, uhash = NULL) {
       self$learner(i = i, uhash = uhash)$param_set$values
@@ -80,7 +80,7 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     predictions = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$predictions()
@@ -93,7 +93,7 @@ ArchiveAsyncTuningFrozen = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     resample_result = function(i = NULL, uhash = NULL) {
       self$benchmark_result$resample_result(i = i, uhash = uhash)

--- a/R/ArchiveBatchTuning.R
+++ b/R/ArchiveBatchTuning.R
@@ -50,7 +50,7 @@
 #' The \CRANpkg{mlr3viz} package provides visualizations for tuning results.
 #'
 #' @section S3 Methods:
-#' * `as.data.table.ArchiveTuning(x, unnest = "x_domain", exclude_columns = "uhash", measures = NULL)`\cr
+#' * `as.data.table.ArchiveBatchTuning(x, unnest = "internal_tuned_values", exclude_columns = "uhash", measures = NULL)`\cr
 #' Returns a tabular view of all evaluated hyperparameter configurations.\cr
 #' [ArchiveBatchTuning] -> [data.table::data.table()]\cr
 #'     * `x` ([ArchiveBatchTuning])
@@ -78,7 +78,7 @@ ArchiveBatchTuning = R6Class(
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
     #' @param check_values (`logical(1)`)\cr
-    #'   If `TRUE` (default), hyperparameter configurations are checked for validity.
+    #'   If `FALSE` (default), hyperparameter configurations are not checked for validity.
     initialize = function(
       search_space,
       codomain,
@@ -102,7 +102,7 @@ ArchiveBatchTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learner
@@ -115,7 +115,7 @@ ArchiveBatchTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learners = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$learners
@@ -128,7 +128,7 @@ ArchiveBatchTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     learner_param_vals = function(i = NULL, uhash = NULL) {
       self$learner(i = i, uhash = uhash)$param_set$values
@@ -141,7 +141,7 @@ ArchiveBatchTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     predictions = function(i = NULL, uhash = NULL) {
       self$resample_result(i = i, uhash = uhash)$predictions()
@@ -154,7 +154,7 @@ ArchiveBatchTuning = R6Class(
     #' @param i (`integer(1)`)\cr
     #'   The iteration value to filter for.
     #'
-    #' @param uhash (`logical(1)`)\cr
+    #' @param uhash (`character(1)`)\cr
     #'   The `uhash` value to filter for.
     resample_result = function(i = NULL, uhash = NULL) {
       self$benchmark_result$resample_result(i = i, uhash = uhash)

--- a/R/ContextAsyncTuning.R
+++ b/R/ContextAsyncTuning.R
@@ -27,7 +27,7 @@ ContextAsyncTuning = R6Class(
       }
     },
 
-    #' @field resample_result ([mlr3::BenchmarkResult])\cr
+    #' @field resample_result ([mlr3::ResampleResult])\cr
     #' The resample result of the hyperparameter configuration currently evaluated.
     resample_result = function(rhs) {
       if (missing(rhs)) {

--- a/R/Tuner.R
+++ b/R/Tuner.R
@@ -47,7 +47,6 @@ Tuner = R6Class(
         param_classes,
         c("ParamLgl", "ParamInt", "ParamDbl", "ParamFct", "ParamUty")
       )
-      # has to have at least multi-crit or single-crit property
       private$.properties = assert_subset(properties, bbotk_reflections$optimizer_properties, empty.ok = FALSE)
       private$.packages = union("mlr3tuning", assert_character(packages, any.missing = FALSE, min.chars = 1L))
       private$.label = assert_string(label, na.ok = TRUE)
@@ -126,7 +125,7 @@ Tuner = R6Class(
 
     #' @field properties (`character()`)\cr
     #' Set of properties of the tuner.
-    #' Must be a subset of [`mlr_reflections$tuner_properties`][mlr3::mlr_reflections].
+    #' Must be a subset of [`bbotk_reflections$optimizer_properties`][bbotk::bbotk_reflections].
     properties = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.properties)) {
         stop("$properties is read-only.")

--- a/R/TunerAsyncFromOptimizerAsync.R
+++ b/R/TunerAsyncFromOptimizerAsync.R
@@ -33,13 +33,13 @@ TunerAsyncFromOptimizerAsync = R6Class(
     },
 
     #' @description
-    #' Performs the tuning on a [TuningInstanceBatchSingleCrit] /
-    #' [TuningInstanceBatchMultiCrit] until termination. The single evaluations and
+    #' Performs the tuning on a [TuningInstanceAsyncSingleCrit] /
+    #' [TuningInstanceAsyncMultiCrit] until termination. The single evaluations and
     #' the final results will be written into the [ArchiveAsyncTuning] that
-    #' resides in the [TuningInstanceBatchSingleCrit]/[TuningInstanceBatchMultiCrit].
+    #' resides in the [TuningInstanceAsyncSingleCrit]/[TuningInstanceAsyncMultiCrit].
     #' The final result is returned.
     #'
-    #' @param inst ([TuningInstanceBatchSingleCrit] | [TuningInstanceBatchMultiCrit]).
+    #' @param inst ([TuningInstanceAsyncSingleCrit] | [TuningInstanceAsyncMultiCrit]).
     #'
     #' @return [data.table::data.table].
     optimize = function(inst) {

--- a/R/TunerAsyncGridSearch.R
+++ b/R/TunerAsyncGridSearch.R
@@ -5,7 +5,7 @@
 #' @description
 #' Subclass for asynchronous grid search tuning.
 #'
-#' @templateVar id async_design_points
+#' @templateVar id async_grid_search
 #' @template section_dictionary_tuners
 #'
 #' @inheritSection bbotk::OptimizerAsyncGridSearch Parameters

--- a/R/TunerBatchGenSA.R
+++ b/R/TunerBatchGenSA.R
@@ -15,7 +15,6 @@
 #' @inheritSection bbotk::OptimizerBatchGenSA Parameters
 #' @inheritSection Tuner Resources
 #' @inheritSection bbotk::OptimizerBatchGenSA Progress Bars
-#' @template section_parallelization
 #' @template section_logging
 #' @templateVar optimizer bbotk::OptimizerBatchGenSA
 #' @template section_optimizer

--- a/R/TunerBatchInternal.R
+++ b/R/TunerBatchInternal.R
@@ -39,7 +39,7 @@
 #' # Internal hyperparameter tuning on the pima indians diabetes data set
 #' instance = tune(
 #'   tnr("internal"),
-#'   tsk("iris"),
+#'   task,
 #'   learner,
 #'   rsmp("cv", folds = 3),
 #'   msr("internal_valid_score", minimize = TRUE, select = "merror")

--- a/R/TunerBatchIrace.R
+++ b/R/TunerBatchIrace.R
@@ -19,7 +19,7 @@
 #' For the meaning of all other parameters, see [irace::defaultScenario()]. Note
 #' that we have removed all control parameters which refer to the termination of
 #' the algorithm. Use [bbotk::TerminatorEvals] instead. Other terminators do not work
-#' with `TunerIrace`.
+#' with `TunerBatchIrace`.
 #'
 #' @section Archive:
 #' The [ArchiveBatchTuning] holds the following additional columns:

--- a/R/TunerBatchNLoptr.R
+++ b/R/TunerBatchNLoptr.R
@@ -10,10 +10,9 @@
 #' @details
 #' The termination conditions `stopval`, `maxtime` and `maxeval` of [nloptr::nloptr()] are deactivated
 #' and replaced by the [bbotk::Terminator] subclasses.
-#' The x and function value tolerance termination conditions (`xtol_rel = 10^-4`,
-#' `xtol_abs = rep(0.0, length(x0))`, `ftol_rel = 0.0` and `ftol_abs = 0.0`)
-#' are still available and implemented with their package defaults.
-#' To deactivate these conditions, set them to `-1`.
+#' The x and function value tolerance termination conditions (`xtol_rel`, `xtol_abs`, `ftol_rel` and `ftol_abs`)
+#' are deactivated by default (initialized to `-1`).
+#' To activate a condition, set it to a positive value.
 #'
 #' @templateVar id nloptr
 #' @template section_dictionary_tuners

--- a/R/TuningInstanceAsyncMulticrit.R
+++ b/R/TuningInstanceAsyncMulticrit.R
@@ -130,7 +130,7 @@ TuningInstanceAsyncMultiCrit = R6Class(
     #' (probably the Pareto set / front).
     #' For internal use.
     #'
-    #' @param ydt (`numeric(1)`)\cr
+    #' @param ydt (`data.table::data.table()`)\cr
     #' Optimal outcomes, e.g. the Pareto front.
     #' @param ... (`any`)\cr
     #' ignored.

--- a/R/TuningInstanceAsyncSingleCrit.R
+++ b/R/TuningInstanceAsyncSingleCrit.R
@@ -16,7 +16,7 @@
 #' If the available budget is exhausted, an exception is raised,
 #' and no further evaluations can be performed from this point on.
 #' The tuner is also supposed to store its final result, consisting of a selected hyperparameter configuration and
-#' associated estimated performance values, by calling the method `instance$.assign_result`.
+#' associated estimated performance values, by calling the method `instance$assign_result`.
 #'
 #' @inheritSection TuningInstanceBatchSingleCrit Default Measures
 #' @inheritSection TuningInstanceBatchSingleCrit Search Space

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -150,10 +150,10 @@ load_callback_async_measures = function() {
 #'   measure = msr("classif.ce"),
 #'   terminator = trm("evals", n_evals = 20),
 #'   store_benchmark_result = FALSE,
-#'   callbacks = clbk("mlr3tuning.rush_mlflow", tracking_uri = "http://localhost:8080")
+#'   callbacks = clbk("mlr3tuning.async_mlflow", tracking_uri = "http://localhost:8080")
 #' )
 #'
-#' tuner = tnr("random_search_v2")
+#' tuner = tnr("async_random_search")
 #' tuner$optimize(instance)
 #' }}
 NULL
@@ -238,7 +238,7 @@ load_callback_async_default_configuration = function() {
   callback_async_tuning(
     "mlr3tuning.async_default_configuration",
     label = "Default Configuration",
-    man = "mlr3tuning::mlr3tuning.default_configuration",
+    man = "mlr3tuning::mlr3tuning.async_default_configuration",
 
     on_optimization_begin = function(callback, context) {
       instance = context$instance
@@ -272,7 +272,7 @@ load_callback_default_configuration = function() {
   callback_batch_tuning(
     "mlr3tuning.default_configuration",
     label = "Default Configuration",
-    man = "mlr3tuning::mlr3tuning.default_configuration",
+    man = "mlr3tuning::mlr3tuning.async_default_configuration",
 
     on_optimization_begin = function(callback, context) {
       instance = context$instance

--- a/R/tune.R
+++ b/R/tune.R
@@ -54,7 +54,7 @@
 #'
 #' @export
 #' @examples
-#' # Hyperparameter optimization on the Palmer Penguins data set
+#' # Hyperparameter optimization on the Pima Indians Diabetes data set
 #' task = tsk("pima")
 #'
 #' # Load learner and set search space

--- a/man-roxygen/param_properties.R
+++ b/man-roxygen/param_properties.R
@@ -1,3 +1,3 @@
 #' @param properties (`character()`)\cr
 #'   Set of properties of the tuner.
-#'   Must be a subset of [`mlr_reflections$tuner_properties`][mlr3::mlr_reflections].
+#'   Must be a subset of [`bbotk_reflections$optimizer_properties`][bbotk::bbotk_reflections].

--- a/man/ArchiveAsyncTuning.Rd
+++ b/man/ArchiveAsyncTuning.Rd
@@ -23,11 +23,10 @@ Lists of (transformed) hyperparameter values that are passed to the learner.
 \item \code{runtime_learners} (\code{numeric(1)})\cr
 Sum of training and predict times logged in learners per \link[mlr3:ResampleResult]{mlr3::ResampleResult} / evaluation.
 This does not include potential overhead time.
-\item \code{timestamp} (\code{POSIXct})\cr
-Time stamp when the evaluation was logged into the archive.
-\item \code{batch_nr} (\code{integer(1)})\cr
-Hyperparameters are evaluated in batches.
-Each batch has a unique batch number.
+\item \code{timestamp_xs} (\code{POSIXct})\cr
+Time stamp when the hyperparameter configuration was sent to a worker.
+\item \code{timestamp_ys} (\code{POSIXct})\cr
+Time stamp when the evaluation result was written to the archive.
 }
 }
 
@@ -40,7 +39,7 @@ The returned data table contains the \link[mlr3:ResampleResult]{mlr3::ResampleRe
 \section{S3 Methods}{
 
 \itemize{
-\item \code{as.data.table.ArchiveTuning(x, unnest = "x_domain", exclude_columns = "uhash", measures = NULL)}\cr
+\item \code{as.data.table.ArchiveAsyncTuning(x, unnest = "internal_tuned_values", exclude_columns = NULL, measures = NULL)}\cr
 Returns a tabular view of all evaluated hyperparameter configurations.\cr
 \link{ArchiveAsyncTuning} -> \code{\link[data.table:data.table]{data.table::data.table()}}\cr
 \itemize{
@@ -135,8 +134,6 @@ Internally created from provided \link[mlr3:Measure]{mlr3::Measure}s.}
 If a rush instance is supplied, the tuning runs without batches.}
       \item{\code{internal_search_space}}{(\link[paradox:ParamSet]{paradox::ParamSet} or \code{NULL})\cr
 The internal search space.}
-      \item{\code{check_values}}{(\code{logical(1)})\cr
-If \code{TRUE} (default), hyperparameter configurations are checked for validity.}
     }
     \if{html}{\out{</div>}}
   }
@@ -159,7 +156,7 @@ Learner does not contain a model. Use \verb{$learners()} to get learners with mo
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -182,7 +179,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -205,7 +202,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -228,7 +225,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -251,7 +248,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}

--- a/man/ArchiveAsyncTuningFrozen.Rd
+++ b/man/ArchiveAsyncTuningFrozen.Rd
@@ -15,7 +15,7 @@ Use the callback \link{mlr3tuning.async_freeze_archive} to freeze the archive af
 \item \code{as.data.table(archive)}\cr
 \link{ArchiveAsyncTuningFrozen} -> \code{\link[data.table:data.table]{data.table::data.table()}}\cr
 Returns a tabular view of all performed function calls of the Objective.
-The \code{x_domain} column is unnested to separate columns.
+The \code{internal_tuned_values} column is unnested to separate columns.
 }
 }
 
@@ -107,7 +107,7 @@ Learner does not contain a model. Use \verb{$learners()} to get learners with mo
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -130,7 +130,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -153,7 +153,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -176,7 +176,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -199,7 +199,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}

--- a/man/ArchiveBatchTuning.Rd
+++ b/man/ArchiveBatchTuning.Rd
@@ -60,7 +60,7 @@ The \CRANpkg{mlr3viz} package provides visualizations for tuning results.
 \section{S3 Methods}{
 
 \itemize{
-\item \code{as.data.table.ArchiveTuning(x, unnest = "x_domain", exclude_columns = "uhash", measures = NULL)}\cr
+\item \code{as.data.table.ArchiveBatchTuning(x, unnest = "internal_tuned_values", exclude_columns = "uhash", measures = NULL)}\cr
 Returns a tabular view of all evaluated hyperparameter configurations.\cr
 \link{ArchiveBatchTuning} -> \code{\link[data.table:data.table]{data.table::data.table()}}\cr
 \itemize{
@@ -143,7 +143,7 @@ When using \code{to_tune()} tokens, dependencies for hierarchical search spaces 
 Specifies codomain of objective function i.e. a set of performance measures.
 Internally created from provided \link[mlr3:Measure]{mlr3::Measure}s.}
       \item{\code{check_values}}{(\code{logical(1)})\cr
-If \code{TRUE} (default), hyperparameter configurations are checked for validity.}
+If \code{FALSE} (default), hyperparameter configurations are not checked for validity.}
       \item{\code{internal_search_space}}{(\link[paradox:ParamSet]{paradox::ParamSet} or \code{NULL})\cr
 The internal search space.}
     }
@@ -168,7 +168,7 @@ Learner does not contain a model. Use \verb{$learners()} to get learners with mo
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -191,7 +191,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -214,7 +214,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -237,7 +237,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}
@@ -260,7 +260,7 @@ The \code{uhash} value to filter for.}
     \describe{
       \item{\code{i}}{(\code{integer(1)})\cr
 The iteration value to filter for.}
-      \item{\code{uhash}}{(\code{logical(1)})\cr
+      \item{\code{uhash}}{(\code{character(1)})\cr
 The \code{uhash} value to filter for.}
     }
     \if{html}{\out{</div>}}

--- a/man/ContextAsyncTuning.Rd
+++ b/man/ContextAsyncTuning.Rd
@@ -21,7 +21,7 @@ Changes to \verb{$instance} and \verb{$optimizer} in the stages executed on the 
 The hyperparameter configuration currently evaluated.
 Contains the values on the learner scale i.e. transformations are applied.}
 
-    \item{\code{resample_result}}{(\link[mlr3:BenchmarkResult]{mlr3::BenchmarkResult})\cr
+    \item{\code{resample_result}}{(\link[mlr3:ResampleResult]{mlr3::ResampleResult})\cr
 The resample result of the hyperparameter configuration currently evaluated.}
 
     \item{\code{aggregated_performance}}{(\code{list()})\cr

--- a/man/Tuner.Rd
+++ b/man/Tuner.Rd
@@ -81,7 +81,7 @@ as given in the \link[paradox:ParamSet]{paradox::ParamSet} \verb{$class} field.}
 
     \item{\code{properties}}{(\code{character()})\cr
 Set of properties of the tuner.
-Must be a subset of \code{\link[mlr3:mlr_reflections]{mlr_reflections$tuner_properties}}.}
+Must be a subset of \code{\link[bbotk:bbotk_reflections]{bbotk_reflections$optimizer_properties}}.}
 
     \item{\code{packages}}{(\code{character()})\cr
 Set of required packages.
@@ -136,7 +136,7 @@ Set of control parameters.}
 Supported parameter classes for learner hyperparameters that the tuner can optimize, as given in the \link[paradox:ParamSet]{paradox::ParamSet} \verb{$class} field.}
       \item{\code{properties}}{(\code{character()})\cr
 Set of properties of the tuner.
-Must be a subset of \code{\link[mlr3:mlr_reflections]{mlr_reflections$tuner_properties}}.}
+Must be a subset of \code{\link[bbotk:bbotk_reflections]{bbotk_reflections$optimizer_properties}}.}
       \item{\code{packages}}{(\code{character()})\cr
 Set of required packages.
 Note that these packages will be loaded via \code{\link[=requireNamespace]{requireNamespace()}}, and are not attached.}

--- a/man/TunerAsyncFromOptimizerAsync.Rd
+++ b/man/TunerAsyncFromOptimizerAsync.Rd
@@ -60,10 +60,10 @@ The referenced help package can be opened via method \verb{$help()}.}
 \if{html}{\out{<a id="method-TunerAsyncFromOptimizerAsync-optimize"></a>}}
 \if{latex}{\out{\hypertarget{method-TunerAsyncFromOptimizerAsync-optimize}{}}}
 \subsection{\code{TunerAsyncFromOptimizerAsync$optimize()}}{
-  Performs the tuning on a \link{TuningInstanceBatchSingleCrit} /
-\link{TuningInstanceBatchMultiCrit} until termination. The single evaluations and
+  Performs the tuning on a \link{TuningInstanceAsyncSingleCrit} /
+\link{TuningInstanceAsyncMultiCrit} until termination. The single evaluations and
 the final results will be written into the \link{ArchiveAsyncTuning} that
-resides in the \link{TuningInstanceBatchSingleCrit}/\link{TuningInstanceBatchMultiCrit}.
+resides in the \link{TuningInstanceAsyncSingleCrit}/\link{TuningInstanceAsyncMultiCrit}.
 The final result is returned.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
@@ -73,7 +73,7 @@ The final result is returned.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{inst}}{(\link{TuningInstanceBatchSingleCrit} | \link{TuningInstanceBatchMultiCrit}).}
+      \item{\code{inst}}{(\link{TuningInstanceAsyncSingleCrit} | \link{TuningInstanceAsyncMultiCrit}).}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/TunerBatch.Rd
+++ b/man/TunerBatch.Rd
@@ -124,7 +124,7 @@ Set of control parameters.}
 Supported parameter classes for learner hyperparameters that the tuner can optimize, as given in the \link[paradox:ParamSet]{paradox::ParamSet} \verb{$class} field.}
       \item{\code{properties}}{(\code{character()})\cr
 Set of properties of the tuner.
-Must be a subset of \code{\link[mlr3:mlr_reflections]{mlr_reflections$tuner_properties}}.}
+Must be a subset of \code{\link[bbotk:bbotk_reflections]{bbotk_reflections$optimizer_properties}}.}
       \item{\code{packages}}{(\code{character()})\cr
 Set of required packages.
 Note that these packages will be loaded via \code{\link[=requireNamespace]{requireNamespace()}}, and are not attached.}

--- a/man/TuningInstanceAsyncMultiCrit.Rd
+++ b/man/TuningInstanceAsyncMultiCrit.Rd
@@ -19,7 +19,7 @@ Before a batch is evaluated, the \link[bbotk:Terminator]{bbotk::Terminator} is q
 If the available budget is exhausted, an exception is raised,
 and no further evaluations can be performed from this point on.
 The tuner is also supposed to store its final result, consisting of a selected hyperparameter configuration and
-associated estimated performance values, by calling the method \code{instance$.assign_result}.
+associated estimated performance values, by calling the method \code{instance$assign_result}.
 }
 \section{Search Space}{
 
@@ -198,7 +198,7 @@ For internal use.
 Hyperparameter values as \code{data.table::data.table()}. Each row is one
 configuration. Contains values in the search space. Can contain additional
 columns for extra information.}
-      \item{\code{ydt}}{(\code{numeric(1)})\cr
+      \item{\code{ydt}}{(\code{data.table::data.table()})\cr
 Optimal outcomes, e.g. the Pareto front.}
       \item{\code{learner_param_vals}}{(List of named \verb{list()s})\cr
 Fixed parameter values of the learner that are neither part of the

--- a/man/TuningInstanceAsyncSingleCrit.Rd
+++ b/man/TuningInstanceAsyncSingleCrit.Rd
@@ -19,7 +19,7 @@ Before a batch is evaluated, the \link[bbotk:Terminator]{bbotk::Terminator} is q
 If the available budget is exhausted, an exception is raised,
 and no further evaluations can be performed from this point on.
 The tuner is also supposed to store its final result, consisting of a selected hyperparameter configuration and
-associated estimated performance values, by calling the method \code{instance$.assign_result}.
+associated estimated performance values, by calling the method \code{instance$assign_result}.
 }
 \section{Default Measures}{
 

--- a/man/mlr3tuning.async_mlflow.Rd
+++ b/man/mlr3tuning.async_mlflow.Rd
@@ -25,10 +25,10 @@ instance = TuningInstanceAsyncSingleCrit$new(
   measure = msr("classif.ce"),
   terminator = trm("evals", n_evals = 20),
   store_benchmark_result = FALSE,
-  callbacks = clbk("mlr3tuning.rush_mlflow", tracking_uri = "http://localhost:8080")
+  callbacks = clbk("mlr3tuning.async_mlflow", tracking_uri = "http://localhost:8080")
 )
 
-tuner = tnr("random_search_v2")
+tuner = tnr("async_random_search")
 tuner$optimize(instance)
 }}
 }

--- a/man/mlr_tuners_async_grid_search.Rd
+++ b/man/mlr_tuners_async_grid_search.Rd
@@ -11,7 +11,7 @@ Subclass for asynchronous grid search tuning.
 
 This \link{Tuner} can be instantiated with the associated sugar function \code{\link[=tnr]{tnr()}}:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{tnr("async_design_points")
+\if{html}{\out{<div class="sourceCode">}}\preformatted{tnr("async_grid_search")
 }\if{html}{\out{</div>}}
 }
 

--- a/man/mlr_tuners_gensa.Rd
+++ b/man/mlr_tuners_gensa.Rd
@@ -30,19 +30,6 @@ This \link{Tuner} can be instantiated with the associated sugar function \code{\
 }\if{html}{\out{</div>}}
 }
 
-\section{Parallelization}{
-
-In order to support general termination criteria and parallelization, we
-evaluate points in a batch-fashion of size \code{batch_size}. Larger batches mean
-we can parallelize more, smaller batches imply a more fine-grained checking
-of termination criteria. A batch consists of \code{batch_size} times \code{resampling$iters} jobs.
-E.g., if you set a batch size of 10 points and do a 5-fold cross validation, you can
-utilize up to 50 cores.
-
-Parallelization is supported via package \CRANpkg{future} (see \code{\link[mlr3:benchmark]{mlr3::benchmark()}}'s
-section on parallelization for more details).
-}
-
 \section{Logging}{
 
 All \link{Tuner}s use a logger (as implemented in \CRANpkg{lgr}) from package

--- a/man/mlr_tuners_internal.Rd
+++ b/man/mlr_tuners_internal.Rd
@@ -88,7 +88,7 @@ learner = lrn("classif.xgboost",
 # Internal hyperparameter tuning on the pima indians diabetes data set
 instance = tune(
   tnr("internal"),
-  tsk("iris"),
+  task,
   learner,
   rsmp("cv", folds = 3),
   msr("internal_valid_score", minimize = TRUE, select = "merror")

--- a/man/mlr_tuners_irace.Rd
+++ b/man/mlr_tuners_irace.Rd
@@ -32,7 +32,7 @@ Number of resampling instances.}
 For the meaning of all other parameters, see \code{\link[irace:defaultScenario]{irace::defaultScenario()}}. Note
 that we have removed all control parameters which refer to the termination of
 the algorithm. Use \link[bbotk:TerminatorEvals]{bbotk::TerminatorEvals} instead. Other terminators do not work
-with \code{TunerIrace}.
+with \code{TunerBatchIrace}.
 }
 
 \section{Archive}{

--- a/man/mlr_tuners_nloptr.Rd
+++ b/man/mlr_tuners_nloptr.Rd
@@ -16,10 +16,9 @@ Calls \link[nloptr:nloptr]{nloptr::nloptr} from package \CRANpkg{nloptr}.
 \details{
 The termination conditions \code{stopval}, \code{maxtime} and \code{maxeval} of \code{\link[nloptr:nloptr]{nloptr::nloptr()}} are deactivated
 and replaced by the \link[bbotk:Terminator]{bbotk::Terminator} subclasses.
-The x and function value tolerance termination conditions (\code{xtol_rel = 10^-4},
-\code{xtol_abs = rep(0.0, length(x0))}, \code{ftol_rel = 0.0} and \code{ftol_abs = 0.0})
-are still available and implemented with their package defaults.
-To deactivate these conditions, set them to \code{-1}.
+The x and function value tolerance termination conditions (\code{xtol_rel}, \code{xtol_abs}, \code{ftol_rel} and \code{ftol_abs})
+are deactivated by default (initialized to \code{-1}).
+To activate a condition, set it to a positive value.
 }
 \section{Dictionary}{
 

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -182,7 +182,7 @@ The \CRANpkg{mlr3viz} package provides visualizations for tuning results.
 }
 
 \examples{
-# Hyperparameter optimization on the Palmer Penguins data set
+# Hyperparameter optimization on the Pima Indians Diabetes data set
 task = tsk("pima")
 
 # Load learner and set search space


### PR DESCRIPTION
Fixes documentation (roxygen and generated man pages) that documented parameters, defaults, types, columns, and identifiers that do not match the code. All items were verified against the code and the installed `bbotk` sources.

## Changes

- **`mlr_tuners_async_grid_search`**: `@templateVar id` was `async_design_points` (wrong tuner); now `async_grid_search`.
- **`TunerAsyncFromOptimizerAsync$optimize()`**: docs referenced the Batch instance classes three times although the code asserts async instances.
- **`mlr_tuners_nloptr`**: the tolerances (`xtol_rel`, `xtol_abs`, `ftol_rel`, `ftol_abs`) are deactivated by default (`init = -1` in bbotk), not active with package defaults.
- **`mlr_tuners_gensa`**: dropped the parallelization section; `OptimizerBatchGenSA` has no `batch_size` and proposes one point per batch.
- **Archive docs** (`ArchiveBatchTuning`, `ArchiveAsyncTuning`, `ArchiveAsyncTuningFrozen`): fixed stale `as.data.table.ArchiveTuning` method name, wrong `unnest`/`exclude_columns`/`check_values` defaults, removed the async `check_values` constructor arg and `timestamp`/`batch_nr` columns that do not exist on the async table, and documented `uhash` as `character(1)` instead of `logical(1)`.
- **default_configuration callbacks**: `man` pointed to the nonexistent topic `mlr3tuning.default_configuration`; now `mlr3tuning.async_default_configuration`.
- **`async_mlflow` example**: used a wrong callback id (`rush_mlflow`) and a nonexistent tuner (`random_search_v2`); now `async_mlflow` and `async_random_search`.
- **`ContextAsyncTuning$resample_result`**: documented as `BenchmarkResult`; it is a `ResampleResult`.
- **`mlr_tuners_internal` example**: constructed `task = tsk("pima")` but tuned `tsk("iris")`; now tunes the constructed `task`.
- **`tune` example**: comment said "Palmer Penguins" over `tsk("pima")`; now "Pima Indians Diabetes".
- **Tuner `properties`**: cited `mlr_reflections$tuner_properties` (does not exist); now `bbotk_reflections$optimizer_properties`, matching the code.
- **`TuningInstanceAsyncMultiCrit$assign_result`**: `@param ydt` typed as `numeric(1)`; it is a `data.table`.
- **`TuningInstanceAsyncSingleCrit`**: fixed stray `instance$.assign_result` (should be `instance$assign_result`).
- **`mlr_tuners_irace`**: fixed stale class name `TunerIrace` -> `TunerBatchIrace`.

Documentation-only change; no `NEWS.md` bullet per project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)