### PR TITLE
chore: remove dead OptimizerBatchInternal class

### DIFF
--- a/R/TunerBatchInternal.R
+++ b/R/TunerBatchInternal.R
@@ -76,25 +76,3 @@ TunerBatchInternal = R6Class(
 )
 
 mlr_tuners$add("internal", TunerBatchInternal)
-
-OptimizerBatchInternal = R6Class(
-  "OptimizerBatchInternal",
-  inherit = bbotk::OptimizerBatch,
-  public = list(
-    initialize = function() {
-      super$initialize(
-        id = "internal",
-        param_set = ps(),
-        param_classes = c("ParamLgl", "ParamInt", "ParamDbl", "ParamFct"),
-        properties = c("dependencies", "single-crit"),
-        label = "Internal Optimizer",
-        man = "bbotk::mlr_optimizers_internal"
-      )
-    }
-  ),
-  private = list(
-    .optimize = function(inst) {
-      inst$eval_batch(data.table())
-    }
-  )
-)


### PR DESCRIPTION
`OptimizerBatchInternal` (`R/TunerBatchInternal.R`) was unexported, unregistered in `mlr_optimizers`, and referenced nowhere in the package or tests. Its `man` field pointed at `bbotk::mlr_optimizers_internal`, a topic that does not exist, so `$help()` would have errored.

Only the sibling `TunerBatchInternal` (registered as `tnr("internal")`) is used. This removes the dead class.

Part of the "Dead code and dead plumbing" cleanup from the package code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)