### PR TITLE
refactor: drop dead id fallback in FromOptimizer tuner wrappers

### DIFF
--- a/R/TunerAsyncFromOptimizerAsync.R
+++ b/R/TunerAsyncFromOptimizerAsync.R
@@ -22,7 +22,7 @@ TunerAsyncFromOptimizerAsync = R6Class(
       assert_string(man, na.ok = TRUE)
 
       super$initialize(
-        id = if ("id" %in% names(optimizer)) optimizer$id else "tuner",
+        id = optimizer$id,
         param_set = optimizer$param_set,
         param_classes = optimizer$param_classes,
         properties = optimizer$properties,

--- a/R/TunerBatchFromBatchOptimizer.R
+++ b/R/TunerBatchFromBatchOptimizer.R
@@ -22,7 +22,7 @@ TunerBatchFromOptimizerBatch = R6Class(
       assert_string(man, na.ok = TRUE)
 
       super$initialize(
-        id = if ("id" %in% names(optimizer)) optimizer$id else "tuner",
+        id = optimizer$id,
         param_set = optimizer$param_set,
         param_classes = optimizer$param_classes,
         properties = optimizer$properties,


### PR DESCRIPTION
Both `TunerBatchFromOptimizerBatch` and `TunerAsyncFromOptimizerAsync` set their id with:

```r
id = if ("id" %in% names(optimizer)) optimizer$id else "tuner",
```

The constructors first call `assert_optimizer()` / `assert_optimizer_async()`, which guarantee a bbotk `Optimizer`. Every `Optimizer` exposes an `id` active binding, so `"id" %in% names(optimizer)` is always `TRUE` and the `else "tuner"` branch is unreachable. Simplified to `id = optimizer$id`.

Part of the "Dead code and dead plumbing" cleanup from the package code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)