### PR TITLE
docs: drop stale roxygen templates in tuning instance classes

### DIFF
--- a/R/TuningInstanceAsyncMulticrit.R
+++ b/R/TuningInstanceAsyncMulticrit.R
@@ -26,7 +26,6 @@
 #'
 #' @template param_xdt
 #' @template param_learner_param_vals
-#' @template param_internal_tuned_values
 #' @template param_extra
 #'
 #' @template field_internal_search_space

--- a/R/TuningInstanceAsyncSingleCrit.R
+++ b/R/TuningInstanceAsyncSingleCrit.R
@@ -36,10 +36,8 @@
 #' @template param_callbacks
 #' @template param_rush
 #'
-#' @template param_internal_search_space
 #' @template param_xdt
 #' @template param_learner_param_vals
-#' @template param_internal_tuned_values
 #' @template param_extra
 #'
 #' @template field_internal_search_space

--- a/R/TuningInstanceBatchMulticrit.R
+++ b/R/TuningInstanceBatchMulticrit.R
@@ -24,10 +24,8 @@
 #' @template param_check_values
 #' @template param_callbacks
 #'
-#' @template param_internal_search_space
 #' @template param_xdt
 #' @template param_learner_param_vals
-#' @template param_internal_tuned_values
 #' @template param_extra
 #'
 #' @template field_internal_search_space

--- a/R/TuningInstanceBatchSingleCrit.R
+++ b/R/TuningInstanceBatchSingleCrit.R
@@ -102,7 +102,6 @@
 #'
 #' @template param_xdt
 #' @template param_learner_param_vals
-#' @template param_internal_tuned_values
 #' @template param_extra
 #'
 #' @template field_internal_search_space


### PR DESCRIPTION
The four `TuningInstance` classes carried `@template param_internal_tuned_values` (and `TuningInstanceAsyncSingleCrit` / `TuningInstanceBatchMultiCrit` additionally `@template param_internal_search_space`). Neither template names a real constructor or method argument:

- `internal_search_space` is a public **field**, documented via `@template field_internal_search_space`.
- `internal_tuned_values` is only a result-table column, never an argument.

roxygen silently dropped these `@param` entries, so re-running `devtools::document()` after removing them produces **no change** to the generated `man/` pages — this is a pure source cleanup.

Part of the "Dead code and dead plumbing" cleanup from the package code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)