### PR TITLE
test: replace pima task with sonar

### DIFF
--- a/R/TunerBatchInternal.R
+++ b/R/TunerBatchInternal.R
@@ -26,7 +26,7 @@
 #' library(mlr3learners)
 #'
 #' # Retrieve task
-#' task = tsk("pima")
+#' task = tsk("sonar")
 #'
 #' # Load learner and set search space
 #' learner = lrn("classif.xgboost",
@@ -36,7 +36,7 @@
 #'   eval_metric = "merror"
 #' )
 #'
-#' # Internal hyperparameter tuning on the pima indians diabetes data set
+#' # Internal hyperparameter tuning on the sonar data set
 #' instance = tune(
 #'   tnr("internal"),
 #'   task,

--- a/R/TunerBatchIrace.R
+++ b/R/TunerBatchIrace.R
@@ -51,14 +51,14 @@
 #' # example only runs if irace is available
 #' if (mlr3misc::require_namespaces("irace", quietly = TRUE)) {
 #' # retrieve task
-#' task = tsk("pima")
+#' task = tsk("sonar")
 #'
 #' # load learner and set search space
 #' learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE))
 #'
 #' # runtime of the example is too long
 #' \donttest{
-#' # hyperparameter tuning on the pima indians diabetes data set
+#' # hyperparameter tuning on the sonar data set
 #' instance = tune(
 #'   tuner = tnr("irace"),
 #'   task = task,

--- a/R/auto_tuner.R
+++ b/R/auto_tuner.R
@@ -33,7 +33,7 @@
 #'   measure = msr("classif.ce"),
 #'   term_evals = 4)
 #'
-#' at$train(tsk("pima"))
+#' at$train(tsk("sonar"))
 auto_tuner = function(
   tuner,
   learner,

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -9,10 +9,10 @@
 #' @examples
 #' clbk("mlr3tuning.backup", path = "backup.rds")
 #'
-#' # tune classification tree on the pima data set
+#' # tune classification tree on the sonar data set
 #' instance = tune(
 #'   tuner = tnr("random_search", batch_size = 2),
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
 #'   resampling = rsmp("cv", folds = 3),
 #'   measures = msr("classif.ce"),
@@ -61,7 +61,7 @@ load_callback_backup = function() {
 #' # additionally score the configurations on the accuracy measure
 #' instance = tune(
 #'   tuner = tnr("random_search", batch_size = 2),
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
 #'   resampling = rsmp("cv", folds = 3),
 #'   measures = msr("classif.ce"),
@@ -144,7 +144,7 @@ load_callback_async_measures = function() {
 #'   cp = to_tune(1e-04, 1e-1))
 #'
 #' instance = TuningInstanceAsyncSingleCrit$new(
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = learner,
 #'   resampling = rsmp("cv", folds = 3),
 #'   measure = msr("classif.ce"),
@@ -346,10 +346,10 @@ load_callback_async_save_logs = function() {
 #' @examples
 #' clbk("mlr3tuning.one_se_rule")
 #'
-#' # Run optimization on the pima data set with the callback
+#' # Run optimization on the sonar data set with the callback
 #' instance = tune(
 #'   tuner = tnr("random_search", batch_size = 15),
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
 #'   resampling = rsmp("cv", folds = 3),
 #'   measures = msr("classif.ce"),

--- a/R/tune.R
+++ b/R/tune.R
@@ -54,8 +54,8 @@
 #'
 #' @export
 #' @examples
-#' # Hyperparameter optimization on the Pima Indians Diabetes data set
-#' task = tsk("pima")
+#' # Hyperparameter optimization on the sonar data set
+#' task = tsk("sonar")
 #'
 #' # Load learner and set search space
 #' learner = lrn("classif.rpart",
@@ -65,7 +65,7 @@
 #' # Run tuning
 #' instance = tune(
 #'   tuner = tnr("random_search", batch_size = 2),
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = learner,
 #'   resampling = rsmp ("holdout"),
 #'   measures = msr("classif.ce"),

--- a/man/auto_tuner.Rd
+++ b/man/auto_tuner.Rd
@@ -177,5 +177,5 @@ at = auto_tuner(
   measure = msr("classif.ce"),
   term_evals = 4)
 
-at$train(tsk("pima"))
+at$train(tsk("sonar"))
 }

--- a/man/mlr3tuning.async_mlflow.Rd
+++ b/man/mlr3tuning.async_mlflow.Rd
@@ -19,7 +19,7 @@ learner = lrn("classif.rpart",
   cp = to_tune(1e-04, 1e-1))
 
 instance = TuningInstanceAsyncSingleCrit$new(
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp("cv", folds = 3),
   measure = msr("classif.ce"),

--- a/man/mlr3tuning.backup.Rd
+++ b/man/mlr3tuning.backup.Rd
@@ -9,10 +9,10 @@ This \link[mlr3misc:Callback]{mlr3misc::Callback} writes the \link[mlr3:Benchmar
 \examples{
 clbk("mlr3tuning.backup", path = "backup.rds")
 
-# tune classification tree on the pima data set
+# tune classification tree on the sonar data set
 instance = tune(
   tuner = tnr("random_search", batch_size = 2),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
   resampling = rsmp("cv", folds = 3),
   measures = msr("classif.ce"),

--- a/man/mlr3tuning.measures.Rd
+++ b/man/mlr3tuning.measures.Rd
@@ -17,7 +17,7 @@ clbk("mlr3tuning.measures")
 # additionally score the configurations on the accuracy measure
 instance = tune(
   tuner = tnr("random_search", batch_size = 2),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
   resampling = rsmp("cv", folds = 3),
   measures = msr("classif.ce"),

--- a/man/mlr3tuning.one_se_rule.Rd
+++ b/man/mlr3tuning.one_se_rule.Rd
@@ -21,10 +21,10 @@ If there are multiple such hyperparameter configurations with the same number of
 \examples{
 clbk("mlr3tuning.one_se_rule")
 
-# Run optimization on the pima data set with the callback
+# Run optimization on the sonar data set with the callback
 instance = tune(
   tuner = tnr("random_search", batch_size = 15),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
   resampling = rsmp("cv", folds = 3),
   measures = msr("classif.ce"),

--- a/man/mlr_tuners_internal.Rd
+++ b/man/mlr_tuners_internal.Rd
@@ -75,7 +75,7 @@ if (mlr3misc::require_namespaces(c("mlr3learners", "xgboost"), quietly = TRUE)) 
 library(mlr3learners)
 
 # Retrieve task
-task = tsk("pima")
+task = tsk("sonar")
 
 # Load learner and set search space
 learner = lrn("classif.xgboost",
@@ -85,7 +85,7 @@ learner = lrn("classif.xgboost",
   eval_metric = "merror"
 )
 
-# Internal hyperparameter tuning on the pima indians diabetes data set
+# Internal hyperparameter tuning on the sonar data set
 instance = tune(
   tnr("internal"),
   task,

--- a/man/mlr_tuners_irace.Rd
+++ b/man/mlr_tuners_irace.Rd
@@ -115,14 +115,14 @@ the most important functions of mlr3tuning.
 # example only runs if irace is available
 if (mlr3misc::require_namespaces("irace", quietly = TRUE)) {
 # retrieve task
-task = tsk("pima")
+task = tsk("sonar")
 
 # load learner and set search space
 learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE))
 
 # runtime of the example is too long
 \donttest{
-# hyperparameter tuning on the pima indians diabetes data set
+# hyperparameter tuning on the sonar data set
 instance = tune(
   tuner = tnr("irace"),
   task = task,

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -182,8 +182,8 @@ The \CRANpkg{mlr3viz} package provides visualizations for tuning results.
 }
 
 \examples{
-# Hyperparameter optimization on the Pima Indians Diabetes data set
-task = tsk("pima")
+# Hyperparameter optimization on the sonar data set
+task = tsk("sonar")
 
 # Load learner and set search space
 learner = lrn("classif.rpart",
@@ -193,7 +193,7 @@ learner = lrn("classif.rpart",
 # Run tuning
 instance = tune(
   tuner = tnr("random_search", batch_size = 2),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp ("holdout"),
   measures = msr("classif.ce"),

--- a/tests/testthat/test_ArchiveAsyncTuning.R
+++ b/tests/testthat/test_ArchiveAsyncTuning.R
@@ -9,7 +9,7 @@ test_that("ArchiveAsyncTuning access methods work", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -65,7 +65,7 @@ test_that("ArchiveAsyncTuning as.data.table function works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -239,7 +239,7 @@ test_that("ArchiveAsyncTuning as.data.table function works without resample resu
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -288,7 +288,7 @@ test_that("ArchiveAsyncTuning benchmark_result errors without stored benchmark r
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -318,7 +318,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with failed points", 
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -345,7 +345,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with empty archive", 
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -377,7 +377,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with new ids in x_dom
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -435,7 +435,7 @@ test_that("ArchiveAsyncTuning as.data.table function works with switched new ids
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -479,7 +479,7 @@ test_that("Saving ArchiveAsyncTuning works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -508,7 +508,7 @@ test_that("ArchiveAsyncTuning as.data.table function works internally tuned valu
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn(
       "classif.debug",
       validate = 0.2,

--- a/tests/testthat/test_ArchiveAsyncTuningFrozen.R
+++ b/tests/testthat/test_ArchiveAsyncTuningFrozen.R
@@ -9,7 +9,7 @@ test_that("ArchiveAsyncTuningFrozen works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -46,7 +46,7 @@ test_that("ArchiveAsyncTuningFrozen as.data.table function works without resampl
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -77,7 +77,7 @@ test_that("ArchiveAsyncTuningFrozen as.data.table function works with failed poi
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_ArchiveBatchTuning.R
+++ b/tests/testthat/test_ArchiveBatchTuning.R
@@ -116,7 +116,7 @@ test_that("ArchiveTuning access methods work", {
 
 test_that("ArchiveTuning as.data.table function works", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -258,7 +258,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   # without benchmark result
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -297,7 +297,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   # empty archive
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -321,7 +321,7 @@ test_that("ArchiveTuning as.data.table function works", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -366,7 +366,7 @@ test_that("ArchiveTuning as.data.table function works", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -397,7 +397,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
   # row order
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -416,7 +416,7 @@ test_that("ArchiveTuning as.data.table function works", {
 
 test_that("ArchiveBatchTuning as.data.table function works for internally tuned values", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn(
       "classif.debug",
       validate = 0.2,

--- a/tests/testthat/test_AutoTuner.R
+++ b/tests/testthat/test_AutoTuner.R
@@ -289,7 +289,7 @@ test_that("store_tuning_instance, store_benchmark_result and store_models flags 
 })
 
 test_that("predict_type works", {
-  task = tsk("pima")
+  task = tsk("sonar")
 
   # response predict type
   at = auto_tuner(
@@ -378,7 +378,7 @@ test_that("AutoTuner get_base_learner method works", {
     measure = msr("classif.ce"),
     term_evals = 1
   )
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   expect_learner(at$base_learner())
   expect_equal(at$base_learner()$id, "classif.rpart")
@@ -397,7 +397,7 @@ test_that("AutoTuner get_base_learner method works", {
     measure = msr("classif.ce"),
     term_evals = 1
   )
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   expect_learner(at$base_learner(recursive = 0))
   expect_equal(at$base_learner(recursive = 0)$id, "graphlearner.classif.rpart")
@@ -490,7 +490,7 @@ test_that("AutoTuner works with empty search space", {
     term_evals = 10
   )
 
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
   expect_equal(at$tuning_instance$result$learner_param_vals[[1]], list(xval = 0))
   expect_equal(at$tuning_instance$result$x_domain, list(list()))
 
@@ -506,7 +506,7 @@ test_that("AutoTuner works with empty search space", {
     term_evals = 10
   )
 
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
   expect_list(at$tuning_instance$result$learner_param_vals[[1]], len = 0)
   expect_equal(at$tuning_instance$result$x_domain, list(list()))
 })
@@ -781,7 +781,7 @@ test_that("AutoTuner works with async tuner", {
     rush = rush
   )
 
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   expect_data_table(at$tuning_instance$result, nrows = 1)
   expect_data_table(at$tuning_instance$archive$data, min.rows = 4)
@@ -896,7 +896,7 @@ test_that("AutoTuner deep clone does not share the trained model", {
     measure = msr("classif.ce"),
     term_evals = 2
   )
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   at2 = at$clone(deep = TRUE)
 

--- a/tests/testthat/test_CallbackAsyncTuning.R
+++ b/tests/testthat/test_CallbackAsyncTuning.R
@@ -16,7 +16,7 @@ test_that("on_optimization_begin works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -42,7 +42,7 @@ test_that("on_optimization_end works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -71,7 +71,7 @@ test_that("on_worker_begin works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -97,7 +97,7 @@ test_that("on_worker_end works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -132,7 +132,7 @@ test_that("on_optimizer_before_eval and on_optimizer_after_eval works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -160,7 +160,7 @@ test_that("on_eval_after_xs works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -192,7 +192,7 @@ test_that("on_eval_after_resample works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -220,7 +220,7 @@ test_that("on_tuning_result_begin in TuningInstanceSingleCrit works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -247,7 +247,7 @@ test_that("on_result_end in TuningInstanceSingleCrit works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -276,7 +276,7 @@ test_that("on_tuning_result_begin in TuningInstanceBatchMultiCrit works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -303,7 +303,7 @@ test_that("on_result_end in TuningInstanceBatchMultiCrit works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -337,7 +337,7 @@ test_that("on_resample_begin works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -371,7 +371,7 @@ test_that("on_resample_before_train works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -404,7 +404,7 @@ test_that("on_resample_before_predict works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -440,7 +440,7 @@ test_that("on_resample_end works", {
 
   instance = tune(
     tuner = tnr("async_random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -472,7 +472,7 @@ test_that("passing a CallbackBatchTuning to an async tuning instance errors", {
   callback = callback_batch_tuning(id = "test")
 
   expect_error(ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_CallbackBatchTuning.R
+++ b/tests/testthat/test_CallbackBatchTuning.R
@@ -7,7 +7,7 @@ test_that("on_optimization_begin works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -26,7 +26,7 @@ test_that("on_optimization_end works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -47,7 +47,7 @@ test_that("on_optimizer_after_eval works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -66,7 +66,7 @@ test_that("on_optimizer_after_eval works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -87,7 +87,7 @@ test_that("on_eval_after_design works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -116,7 +116,7 @@ test_that("on_eval_after_benchmark and on_eval_before_archive works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -138,7 +138,7 @@ test_that("on_tuning_result_begin in TuningInstanceSingleCrit works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -158,7 +158,7 @@ test_that("on_result_end in TuningInstanceSingleCrit works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -180,7 +180,7 @@ test_that("on_tuning_result_begin in TuningInstanceBatchMultiCrit works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -200,7 +200,7 @@ test_that("on_result_end in TuningInstanceBatchMultiCrit works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -227,7 +227,7 @@ test_that("on_resample_begin works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -254,7 +254,7 @@ test_that("on_resample_before_train works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -280,7 +280,7 @@ test_that("on_resample_before_predict works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -307,7 +307,7 @@ test_that("on_resample_end works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -328,7 +328,7 @@ test_that("passing a CallbackAsyncTuning to a batch tuning instance errors", {
   callback = callback_async_tuning(id = "test")
 
   expect_error(ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_ObjectiveTuningAsync.R
+++ b/tests/testthat/test_ObjectiveTuningAsync.R
@@ -1,6 +1,6 @@
 test_that("objective async works", {
   objective = ObjectiveTuningAsync$new(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -20,7 +20,7 @@ test_that("objective async works", {
 
 test_that("store benchmark result works", {
   objective = ObjectiveTuningAsync$new(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -42,7 +42,7 @@ test_that("store benchmark result works", {
 
 test_that("store models works", {
   objective = ObjectiveTuningAsync$new(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -64,7 +64,7 @@ test_that("store models works", {
 
 test_that("rush objective with multiple measures works", {
   objective = ObjectiveTuningAsync$new(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),

--- a/tests/testthat/test_Tuner.R
+++ b/tests/testthat/test_Tuner.R
@@ -301,7 +301,7 @@ test_that("internal multi crit", {
 
 test_that("proper error when primary search space is empty", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn(
       "classif.debug",
       validate = 0.2,
@@ -348,7 +348,7 @@ test_that("internal tuning: branching", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerAsyncDesignPoints.R
+++ b/tests/testthat/test_TunerAsyncDesignPoints.R
@@ -11,7 +11,7 @@ test_that("TunerAsyncDesignPoints works", {
   learner = lrn("classif.rpart", minsplit = to_tune(2, 128), cp = to_tune(1e-04, 1e-1))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerAsyncGridSearch.R
+++ b/tests/testthat/test_TunerAsyncGridSearch.R
@@ -11,7 +11,7 @@ test_that("TunerAsyncGridSearch works", {
   learner = lrn("classif.rpart", minsplit = to_tune(2, 128), cp = to_tune(1e-04, 1e-1))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerAsyncRandomSearch.R
+++ b/tests/testthat/test_TunerAsyncRandomSearch.R
@@ -11,7 +11,7 @@ test_that("TunerAsyncRandomSearch works", {
   learner = lrn("classif.rpart", minsplit = to_tune(2, 128), cp = to_tune(1e-04, 1e-1))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerBatchCmaes.R
+++ b/tests/testthat/test_TunerBatchCmaes.R
@@ -12,7 +12,7 @@ test_that("TunerBatchCmaes", {
 
   instance = tune(
     tuner = tnr("cmaes"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerBatchFromOptimizerBatch.R
+++ b/tests/testthat/test_TunerBatchFromOptimizerBatch.R
@@ -1,6 +1,6 @@
 test_that("TunerBatchFromOptimizerBatch parameter set works after cloning", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerInternal.R
+++ b/tests/testthat/test_TunerInternal.R
@@ -1,7 +1,7 @@
 test_that("tuner internal works", {
   measure = msr("internal_valid_score", minimize = FALSE, select = "acc")
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn(
       "classif.debug",
       validate = 0.2,

--- a/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceAsyncMultiCrit.R
@@ -9,7 +9,7 @@ test_that("initializing TuningInstanceAsyncSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -34,7 +34,7 @@ test_that("TuningInstanceAsyncSingleCrit can be passed to a tuner", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -56,7 +56,7 @@ test_that("assigning a result to TuningInstanceAsyncSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -79,7 +79,7 @@ test_that("assign_result checks learner_param_vals", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -102,7 +102,7 @@ test_that("assign_result works with empty search space and front size not divisi
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -126,7 +126,7 @@ test_that("saving the benchmark result with TuningInstanceRushSingleCrit works",
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -151,7 +151,7 @@ test_that("saving the models with TuningInstanceRushSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -180,7 +180,7 @@ test_that("saving the models with TuningInstanceRushSingleCrit works", {
 #   learner$encapsulate = c(train = "callr")
 
 #   instance = ti_async(
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = learner,
 #     resampling = rsmp("cv", folds = 3),
 #     measures = msr("classif.ce"),
@@ -251,7 +251,7 @@ test_that("tiny logging works", {
   on.exit(options(old_opts), add = TRUE)
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -282,7 +282,7 @@ test_that("tiny logging work with internal tuning", {
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),

--- a/tests/testthat/test_TuningInstanceAsyncSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceAsyncSingleCrit.R
@@ -9,7 +9,7 @@ test_that("initializing TuningInstanceAsyncSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -33,7 +33,7 @@ test_that("TuningInstanceAsyncSingleCrit can be passed to a tuner", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -55,7 +55,7 @@ test_that("assigning a result to TuningInstanceAsyncSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -79,7 +79,7 @@ test_that("saving the benchmark result with TuningInstanceRushSingleCrit works",
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -104,7 +104,7 @@ test_that("saving the models with TuningInstanceRushSingleCrit works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -130,7 +130,7 @@ test_that("saving the models with TuningInstanceRushSingleCrit works", {
 #   })
 
 #   instance = ti_async(
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.debug", segfault_train = 1, x = to_tune()),
 #     resampling = rsmp("cv", folds = 3),
 #     measures = msr("classif.ce"),
@@ -161,7 +161,7 @@ test_that("Async single-crit internal tuning works", {
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -237,7 +237,7 @@ test_that("tiny logging works", {
   on.exit(options(old_opts), add = TRUE)
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -268,7 +268,7 @@ test_that("tiny logging work with internal tuning", {
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TuningInstanceBatchMultiCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchMultiCrit.R
@@ -1,5 +1,5 @@
 test_that("tuning with multiple objectives", {
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   learner = lrn("classif.rpart")
 
@@ -160,7 +160,7 @@ test_that("TuningInstanceBatchMultiCrit and empty search space works", {
   # xval constant
   instance = tune(
     tuner = tnr("random_search", batch_size = 5),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -174,7 +174,7 @@ test_that("TuningInstanceBatchMultiCrit and empty search space works", {
   # xval and cp constant
   instance = tune(
     tuner = tnr("random_search", batch_size = 5),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", xval = 0, cp = 0.1),
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -191,7 +191,7 @@ test_that("TuningInstanceBatchMultiCrit and empty search space works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 5),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -205,7 +205,7 @@ test_that("TuningInstanceBatchMultiCrit and empty search space works", {
 
 test_that("assign_result works with empty search space and front size not divisible by number of measures", {
   instance = TuningInstanceBatchMultiCrit$new(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -232,7 +232,7 @@ test_that("Batch multi-crit internal tuning works", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msrs(c("classif.ce", "classif.acc")),

--- a/tests/testthat/test_TuningInstanceBatchSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchSingleCrit.R
@@ -85,10 +85,10 @@ test_that("the same experiment can be added twice", {
 
 
 test_that("tuning with custom resampling", {
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("custom")
-  train_sets = list(1:300, 332:632)
-  test_sets = list(301:331, 633:663)
+  train_sets = list(c(1:40, 98:137), c(41:80, 138:177))
+  test_sets = list(c(81:90, 178:187), c(91:97, 188:197))
   resampling$instantiate(task, train_sets, test_sets)
 
   learner = lrn("classif.rpart")
@@ -289,7 +289,7 @@ test_that("TuningInstanceBatchSingleCrit and empty search space works", {
   # xval constant
   instance = tune(
     tuner = tnr("random_search", batch_size = 5),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -306,7 +306,7 @@ test_that("TuningInstanceBatchSingleCrit and empty search space works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 5),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -321,7 +321,7 @@ test_that("TuningInstanceBatchSingleCrit and empty search space works", {
 test_that("assign_result works with one hyperparameter", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1))
   learner$param_set$values$xval = NULL
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -342,7 +342,7 @@ test_that("assign_result works with one hyperparameter", {
 test_that("assign_result works with two hyperparameters", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1), minbucket = to_tune(1, 12))
   learner$param_set$values$xval = NULL
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -363,7 +363,7 @@ test_that("assign_result works with two hyperparameters", {
 
 test_that("assign_result works with two hyperparameters and one constant", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1), minbucket = to_tune(1, 12), xval = 1)
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -384,7 +384,7 @@ test_that("assign_result works with two hyperparameters and one constant", {
 
 test_that("assign_result works with no hyperparameters and one constant", {
   learner = lrn("classif.rpart", xval = 1)
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -404,7 +404,7 @@ test_that("assign_result works with no hyperparameters and one constant", {
 
 test_that("assign_result works with no hyperparameters and two constant", {
   learner = lrn("classif.rpart", xval = 1, cp = 1)
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -423,7 +423,7 @@ test_that("assign_result works with no hyperparameters and two constant", {
 
 test_that("assign_result works with one hyperparameters and one constant", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1), xval = 1)
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -444,7 +444,7 @@ test_that("assign_result works with one hyperparameters and one constant", {
 test_that("assign_result works with no hyperparameter and constant", {
   learner = lrn("classif.rpart")
   learner$param_set$values$xval = NULL
-  task = tsk("pima")
+  task = tsk("sonar")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
   terminator = trm("evals", n_evals = 10)
@@ -462,7 +462,7 @@ test_that("assign_result works with no hyperparameter and constant", {
 })
 
 test_that("objective contains no benchmark results", {
-  task = tsk("pima")
+  task = tsk("sonar")
   learner = lrn("classif.rpart")
   resampling = rsmp("holdout")
   measure = msr("classif.ce")
@@ -482,7 +482,7 @@ test_that("dependencies in defaults work", {
   expect_class(
     tune(
       tuner = tnr("random_search", batch_size = 5),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
@@ -494,7 +494,7 @@ test_that("dependencies in defaults work", {
   expect_error(
     tune(
       tuner = tnr("random_search", batch_size = 5),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
@@ -517,7 +517,7 @@ test_that("Batch single-crit internal tuning works", {
   )
 
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_auto_tuner.R
+++ b/tests/testthat/test_auto_tuner.R
@@ -56,7 +56,7 @@ test_that("async auto tuner works", {
   )
 
   expect_class(at, "AutoTuner")
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   expect_class(at$tuning_instance, "TuningInstanceAsyncSingleCrit")
 })
@@ -81,7 +81,7 @@ test_that("async auto tuner works with rush controller", {
 
   expect_class(at, "AutoTuner")
   expect_class(at$instance_args$rush, "Rush")
-  at$train(tsk("pima"))
+  at$train(tsk("sonar"))
 
   expect_class(at$tuning_instance, "TuningInstanceAsyncSingleCrit")
 })

--- a/tests/testthat/test_lgr.R
+++ b/tests/testthat/test_lgr.R
@@ -13,7 +13,7 @@
 #   # log level is inherited from root logger
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -26,7 +26,7 @@
 #   lgr::get_logger("mlr3")$set_threshold("error")
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -38,7 +38,7 @@
 #   lgr::get_logger("mlr3")$set_threshold("info")
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -51,7 +51,7 @@
 #   lgr::get_logger("mlr3/bbotk")$set_threshold("error")
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -65,7 +65,7 @@
 #   lgr::get_logger("mlr3/core")$set_threshold("error")
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -81,7 +81,7 @@
 #   lgr::get_logger("mlr3/bbotk")$set_threshold("error")
 #   res = capture_output(tune(
 #     tuner = tnr("random_search"),
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = lrn("classif.featureless"),
 #     resampling = rsmp("cv", folds = 3L),
 #     measures = msr("classif.acc"),
@@ -107,7 +107,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),
@@ -122,7 +122,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),
@@ -136,7 +136,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),
@@ -151,7 +151,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),
@@ -167,7 +167,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),
@@ -185,7 +185,7 @@
 #   res = capture_output(with_future(future::multisession, {
 #     tune(
 #       tuner = tnr("random_search"),
-#       task = tsk("pima"),
+#       task = tsk("sonar"),
 #       learner = lrn("classif.featureless"),
 #       resampling = rsmp("cv", folds = 3L),
 #       measures = msr("classif.acc"),

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -5,7 +5,7 @@ test_that("backup callback works", {
 
   instance = tune(
     tuner = tnr("random_search", batch_size = 2),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -22,7 +22,7 @@ test_that("backup callback works with standalone tuner", {
 
   instance = tune(
     tuner = tnr("grid_search", batch_size = 2),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -39,7 +39,7 @@ test_that("backup callback works with standalone tuner", {
 test_that("batch measures callback works", {
   instance = tune(
     tuner = tnr("random_search", batch_size = 2),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -62,7 +62,7 @@ test_that("async measures callback works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1), predict_sets = "test"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -97,7 +97,7 @@ test_that("async measures callback works", {
 #     cp        = to_tune(1e-04, 1e-1))
 
 #   instance = ti_async(
-#     task = tsk("pima"),
+#     task = tsk("sonar"),
 #     learner = learner,
 #     resampling = rsmp("cv", folds = 3),
 #     measures = msr("classif.ce"),
@@ -123,7 +123,7 @@ test_that("default configuration callback works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -149,7 +149,7 @@ test_that("default configuration callback works with logscale", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -175,7 +175,7 @@ test_that("default configuration callback errors with trafo", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(p_dbl(-10, 0, trafo = function(x) 10^x))),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -200,7 +200,7 @@ test_that("default configuration callback works without transformation and with 
   learner = lrn("classif.rpart", cp = to_tune(1e-3, 1, logscale = TRUE), minbucket = to_tune(1, 20))
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -235,7 +235,7 @@ test_that("default configuration callback errors without transformation and with
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -269,7 +269,7 @@ test_that("default configuration callback errors with extra trafo", {
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -298,7 +298,7 @@ test_that("default configuration callback errors with old parameter set api", {
   )
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -466,7 +466,7 @@ test_that("async save logs callback works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.debug", message_train = 1, x = to_tune()),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -487,7 +487,7 @@ test_that("async save logs callback works", {
 test_that("one se rule callback works", {
   instance = tune(
     tuner = tnr("random_search", batch_size = 15),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1, logscale = TRUE)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -509,7 +509,7 @@ test_that("one se rule callback works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),
@@ -538,7 +538,7 @@ test_that("async freeze archive callback works", {
   })
 
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune(1e-04, 1e-1)),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_ti.R
+++ b/tests/testthat/test_ti.R
@@ -1,6 +1,6 @@
 test_that("ti function creates a TuningInstanceBatchSingleCrit", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune()),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -11,7 +11,7 @@ test_that("ti function creates a TuningInstanceBatchSingleCrit", {
 
 test_that("ti function creates a TuningInstanceBatchMultiCrit", {
   instance = ti(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune()),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),

--- a/tests/testthat/test_ti_async.R
+++ b/tests/testthat/test_ti_async.R
@@ -3,7 +3,7 @@ skip_if_no_redis()
 
 test_that("ti_async function creates a TuningInstanceAsyncSingleCrit", {
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune()),
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -14,7 +14,7 @@ test_that("ti_async function creates a TuningInstanceAsyncSingleCrit", {
 
 test_that("ti_async function creates a TuningInstanceAsyncMultiCrit", {
   instance = ti_async(
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.rpart", cp = to_tune()),
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),

--- a/tests/testthat/test_tune.R
+++ b/tests/testthat/test_tune.R
@@ -2,7 +2,7 @@ test_that("tune function works with one measure", {
   learner = lrn("classif.rpart", minsplit = to_tune(1, 10))
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("holdout"),
     measures = msr("classif.ce"),
@@ -23,7 +23,7 @@ test_that("tune errors when rush is used with a batch tuner", {
   expect_error(
     tune(
       tuner = tnr("random_search", batch_size = 1),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = lrn("classif.rpart", minsplit = to_tune(1, 10)),
       resampling = rsmp("holdout"),
       measures = msr("classif.ce"),
@@ -38,7 +38,7 @@ test_that("tune function works with multiple measures", {
   learner = lrn("classif.rpart", minsplit = to_tune(1, 10))
   instance = tune(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("holdout"),
     measures = msrs(c("classif.ce", "classif.acc")),
@@ -54,7 +54,7 @@ test_that("tune function works without measure", {
   learner = lrn("classif.rpart", minsplit = to_tune(1, 10))
   instance = tune(
     tuner = tnr("random_search"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("holdout"),
     term_evals = 2

--- a/tests/testthat/test_tune_nested.R
+++ b/tests/testthat/test_tune_nested.R
@@ -4,7 +4,7 @@ test_that("tune_nested function works", {
 
   rr = tune_nested(
     tuner = tnr("random_search", batch_size = 1),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     inner_resampling = rsmp("holdout"),
     outer_resampling = rsmp("cv", folds = 3),


### PR DESCRIPTION
## Why

The `pima` task is being removed from mlr3 because the `PimaIndiansDiabetes2` dataset was removed from the mlbench package. This PR removes all usage of `tsk("pima")` from mlr3tuning.

## What

- Replace every `tsk("pima")` with the default `tsk("sonar")` binary classification task across tests, examples, and generated documentation (man/*.Rd).
- Update prose that referenced the "Pima Indians Diabetes data set" to reference sonar.
- In the custom-resampling test (`test_TuningInstanceBatchSingleCrit.R`), the hardcoded row indices assumed pima's 768 rows. Rescale them to sonar's 208 rows and mix both classes per fold, since sonar is sorted by class (rows 1-97 are one class, 98-208 the other) and single-class folds break rpart.

## Notes

- `man/*.Rd` were edited directly (same text substitution) rather than regenerated, to avoid unrelated reformatting noise from a differing local roxygen2 version.
- No tuning logic depended on pima's missing values or specific feature count, so a straight swap to sonar is sufficient.

## Testing

Full test suite: 0 failed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)