### PR TITLE
Test Paradox 2 dormant dependency values

### DIFF
--- a/inst/testthat/helper_misc.R
+++ b/inst/testthat/helper_misc.R
@@ -45,7 +45,7 @@ TEST_MAKE_INST1_2D = function(
 # create inst object with dependencies
 TEST_MAKE_PS2 = function() {
   ps = ps(
-    xx = p_fct(levels = c("a", "b"), default = "a"),
+    xx = p_fct(levels = c("a", "b")),
     yy = p_dbl(lower = 0, upper = 1),
     cp = p_dbl(lower = 0, upper = 1)
   )

--- a/tests/testthat/test_TuningInstanceBatchSingleCrit.R
+++ b/tests/testthat/test_TuningInstanceBatchSingleCrit.R
@@ -479,19 +479,7 @@ test_that("dependencies in defaults work", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1))
   learner$param_set$add_dep("cp", "keep_model", CondEqual$new("keep_model" == TRUE))
 
-  expect_class(
-    tune(
-      tuner = tnr("random_search", batch_size = 5),
-      task = tsk("sonar"),
-      learner = learner,
-      resampling = rsmp("cv", folds = 3),
-      measures = msr("classif.ce"),
-      terminator = trm("evals", n_evals = 20)
-    ),
-    "TuningInstanceBatchSingleCrit"
-  )
-
-  expect_error(
+  tune_instance = function(check_values = FALSE) {
     tune(
       tuner = tnr("random_search", batch_size = 5),
       task = tsk("sonar"),
@@ -499,10 +487,21 @@ test_that("dependencies in defaults work", {
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
       terminator = trm("evals", n_evals = 20),
-      check_values = TRUE
-    ),
-    regexp = "Assertion on"
-  )
+      check_values = check_values
+    )
+  }
+
+  expect_r6(tune_instance(), "TuningInstanceBatchSingleCrit")
+
+  if (packageVersion("paradox") < "2.0.0") {
+    expect_error(tune_instance(check_values = TRUE), regexp = "Assertion on")
+  } else {
+    instance = tune_instance(check_values = TRUE)
+    expect_r6(instance, "TuningInstanceBatchSingleCrit")
+    expect_equal(instance$search_space$ids(), "cp")
+    expect_data_table(instance$archive$data, nrows = 20L)
+    expect_number(instance$result_learner_param_vals$cp, lower = 0.01, upper = 0.1)
+  }
 })
 
 # Internal Tuning --------------------------------------------------------------


### PR DESCRIPTION

> Preserve the two strict point-validation tests as genuine store-blind,
> no-default checks by removing the accidental default from their test helper.
> Version-gate only the TuneToken-child case whose documented behavior differs:
> Paradox 1 retains its historical assertion error, while Paradox 2 skips the
> incoming dependency edge and accepts later domain-valid dormant values.
>
> This is a test-only compatibility adaptation. Complete mlr3tuning suites pass
> against both Paradox 1 and 2, and no runtime validation is disabled.

